### PR TITLE
fix: Set request content-type encoding to UTF-8

### DIFF
--- a/src/main/java/com/google/genai/HttpApiClient.java
+++ b/src/main/java/com/google/genai/HttpApiClient.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 
 /** Base client for the HTTP APIs. */
@@ -67,7 +68,7 @@ final class HttpApiClient extends ApiClient {
       httpPost.setHeader("Authorization", "Bearer " + cred.getAccessToken().getTokenValue());
     }
 
-    httpPost.setEntity(new StringEntity(requestJson));
+    httpPost.setEntity(new StringEntity(requestJson, ContentType.APPLICATION_JSON));
 
     HttpApiResponse httpApiResponse = new HttpApiResponse(httpClient.execute(httpPost));
     return httpApiResponse;


### PR DESCRIPTION
Do not use `new StringEntity` without specifying a ContentType.

All non-English characters, are broken because of the code below.

```
TEXT_PLAIN = create("text/plain", Consts.ISO_8859_1);
DEFAULT_TEXT = TEXT_PLAIN;
public StringEntity(String string) throws UnsupportedEncodingException {
    this(string, ContentType.DEFAULT_TEXT);
}
```

ContentType.APPLICATION_JSON uses UTF-8.