### PR TITLE
fix: Use `orElseGet` to defer loading of default credentials

### DIFF
--- a/src/main/java/com/google/genai/ApiClient.java
+++ b/src/main/java/com/google/genai/ApiClient.java
@@ -104,7 +104,7 @@ abstract class ApiClient {
       throw new IllegalArgumentException("Location must not be empty.");
     }
 
-    this.credentials = Optional.of(credentials.orElse(defaultCredentials()));
+    this.credentials = Optional.of(credentials.orElseGet(() -> defaultCredentials()));
 
     this.httpOptions = defaultHttpOptions(/* vertexAI= */ true, this.location);
 


### PR DESCRIPTION
When constructing a `Client` with explicitly provided `credentials`, the `ApiClient` constructor still throws an error about failing to get application default credentials. For example:

```java
Client client = Client.builder()
  .credentials(...)
  .project("...")
  .location("...")
  .vertexAI(true)
  .build();
/*
java.lang.IllegalArgumentException: Failed to get application default credentials, please explicitly provide credentials.
	at com.google.genai.ApiClient.<init>(ApiClient.java:109)
	at com.google.genai.HttpApiClient.<init>(HttpApiClient.java:43)
	at com.google.genai.Client.<init>(Client.java:203)
	at com.google.genai.Client.<init>(Client.java:27)
	at com.google.genai.Client$Builder.build(Client.java:55)
	...
*/
```


As a fix, this defers loading of the application default credentials by calling `orElseGet` instead of `orElse` on the given `credentials`.