### PR TITLE
Fixes #372 - Add support for building Native Java images for the Java GenAI library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+target/
+
+### IntelliJ IDEA ###
+.idea/*
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+### .env files contain local environment variables ###
+.env
+langchain4j-core/target_test-classes/

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
           <executions>
             <execution>
               <id>attach-sources</id>
+              <phase>package</phase>
               <goals>
                 <goal>jar-no-fork</goal>
               </goals>
@@ -333,6 +334,110 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+        <version>0.10.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <buildArgs>
+            <buildArg>--no-fallback</buildArg>
+            <buildArg>--verbose</buildArg>
+          </buildArgs>
+        </configuration>
+      </plugin>
     </plugins>
-  </build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources/META-INF/native-image/com.google.genai/google-genai</directory>
+        <targetPath>META-INF/native-image/com.google.genai/google-genai</targetPath>
+      </resource>
+      <resource>
+        <directory>target/native-image</directory>
+        <targetPath>META-INF/native-image/com.google.genai/google-genai</targetPath>
+      </resource>
+    </resources>
+    </build>
+    <profiles>
+      <profile>
+        <id>native</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.graalvm.buildtools</groupId>
+              <artifactId>native-maven-plugin</artifactId>
+              <version>0.10.2</version>
+              <extensions>true</extensions>
+              <executions>
+                <execution>
+                  <id>build-native</id>
+                  <goals>
+                    <goal>compile-no-fork</goal>
+                  </goals>
+                  <phase>package</phase>
+                </execution>
+              </executions>
+              <configuration>
+                <buildArgs>
+                  <buildArg>--no-fallback</buildArg>
+                  <buildArg>--verbose</buildArg>
+                  <buildArg>-Ob</buildArg>
+                </buildArgs>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+      <profile>
+        <id>native-image</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.graalvm.buildtools</groupId>
+              <artifactId>native-maven-plugin</artifactId>
+              <version>0.10.2</version>
+              <extensions>true</extensions>
+              <executions>
+                <execution>
+                  <id>build-native</id>
+                  <goals>
+                    <goal>compile-no-fork</goal>
+                  </goals>
+                  <phase>package</phase>
+                </execution>
+              </executions>
+              <configuration>
+                <sharedLibrary>true</sharedLibrary>
+                <buildArgs>
+                  <buildArg>--no-fallback</buildArg>
+                  <buildArg>--verbose</buildArg>
+                  <buildArg>-O3</buildArg>
+                </buildArgs>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+      <profile>
+        <id>native-tests</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <argLine>@{argLine} -agentlib:native-image-agent=config-output-dir=target/native-image</argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.genai</groupId>
   <artifactId>google-genai</artifactId>
   <name>google-genai</name>
-  <version>1.7.0-SNAPSHOT</version><!-- {x-version-update:google-genai:current} -->
+  <version>1.7.0-SNAPSHOT
+  </version><!-- {x-version-update:google-genai:current} -->
   <packaging>jar</packaging>
   <description>
     Java idiomatic SDK for the Gemini Developer APIs and Vertex AI APIs.
@@ -61,7 +62,9 @@
     <repository>
       <id>ossrh</id>
       <name>Central Repository OSSRH</name>
-      <url>https://google.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>
+        https://google.oss.sonatype.org/service/local/staging/deploy/maven2/
+      </url>
     </repository>
     <snapshotRepository>
       <id>ossrh</id>
@@ -131,7 +134,7 @@
       <artifactId>Java-WebSocket</artifactId>
       <version>${java-websocket.version}</version>
     </dependency>
-    <!-- JUnit 5 -->
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
@@ -156,14 +159,14 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- Mockito -->
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- jspecify -->
+
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
@@ -178,14 +181,14 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement>
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>
@@ -207,16 +210,17 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.2</version>
           <dependencies>
-          <!-- tree view output test results: https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html#external-extensions-for-the-plugin -->
-              <dependency>
-                  <groupId>me.fabriciorby</groupId>
-                  <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
-                  <version>0.1.0</version>
-              </dependency>
+
+            <dependency>
+              <groupId>me.fabriciorby</groupId>
+              <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+              <version>0.1.0</version>
+            </dependency>
           </dependencies>
           <configuration>
-              <reportFormat>plain</reportFormat>
-              <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
+            <reportFormat>plain</reportFormat>
+            <statelessTestsetInfoReporter
+                implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
           </configuration>
         </plugin>
         <plugin>
@@ -231,7 +235,7 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>
@@ -286,7 +290,8 @@
             <show>public</show>
             <doclint>html</doclint>
             <nohelp>true</nohelp>
-            <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+            <outputDirectory>${project.build.directory}/javadoc
+            </outputDirectory>
             <doctitle>Google Gen AI Java SDK</doctitle>
             <source>${maven.compiler.source}</source>
             <encoding>UTF-8</encoding>
@@ -350,82 +355,24 @@
           </buildArgs>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <filtering>false</filtering>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>
         <directory>src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>src/main/resources/META-INF/native-image/com.google.genai/google-genai</directory>
-        <targetPath>META-INF/native-image/com.google.genai/google-genai</targetPath>
-      </resource>
-      <resource>
-        <directory>target/native-image</directory>
-        <targetPath>META-INF/native-image/com.google.genai/google-genai</targetPath>
+        <filtering>false</filtering>
       </resource>
     </resources>
-    </build>
-    <profiles>
-      <profile>
-        <id>native</id>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>org.graalvm.buildtools</groupId>
-              <artifactId>native-maven-plugin</artifactId>
-              <version>0.10.2</version>
-              <extensions>true</extensions>
-              <executions>
-                <execution>
-                  <id>build-native</id>
-                  <goals>
-                    <goal>compile-no-fork</goal>
-                  </goals>
-                  <phase>package</phase>
-                </execution>
-              </executions>
-              <configuration>
-                <buildArgs>
-                  <buildArg>--no-fallback</buildArg>
-                  <buildArg>--verbose</buildArg>
-                  <buildArg>-Ob</buildArg>
-                </buildArgs>
-              </configuration>
-            </plugin>
-          </plugins>
-        </build>
-      </profile>
-      <profile>
-        <id>native-image</id>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>org.graalvm.buildtools</groupId>
-              <artifactId>native-maven-plugin</artifactId>
-              <version>0.10.2</version>
-              <extensions>true</extensions>
-              <executions>
-                <execution>
-                  <id>build-native</id>
-                  <goals>
-                    <goal>compile-no-fork</goal>
-                  </goals>
-                  <phase>package</phase>
-                </execution>
-              </executions>
-              <configuration>
-                <sharedLibrary>true</sharedLibrary>
-                <buildArgs>
-                  <buildArg>--no-fallback</buildArg>
-                  <buildArg>--verbose</buildArg>
-                  <buildArg>-O3</buildArg>
-                </buildArgs>
-              </configuration>
-            </plugin>
-          </plugins>
-        </build>
-      </profile>
-      <profile>
+  </build>
+  <profiles>
+
+    <profile>
         <id>native-tests</id>
         <build>
           <plugins>
@@ -439,5 +386,35 @@
           </plugins>
         </build>
       </profile>
-    </profiles>
+    <profile>
+      <id>native-image</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.10.2</version>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>compile-no-fork</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <sharedLibrary>true</sharedLibrary>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>--verbose</buildArg>
+                <buildArg>-O3</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -385,9 +385,10 @@
             </plugin>
           </plugins>
         </build>
-      </profile>
+    </profile>
+    <!--
     <profile>
-      <id>native-image</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>
@@ -407,8 +408,8 @@
             <configuration>
               <sharedLibrary>true</sharedLibrary>
               <buildArgs>
-                <buildArg>--no-fallback</buildArg>
-                <buildArg>--verbose</buildArg>
+                <buildArg>-no-fallback</buildArg>
+                <buildArg>-verbose</buildArg>
                 <buildArg>-O3</buildArg>
               </buildArgs>
             </configuration>
@@ -416,5 +417,6 @@
         </plugins>
       </build>
     </profile>
+    -->
   </profiles>
 </project>

--- a/src/main/java/com/google/genai/Common.java
+++ b/src/main/java/com/google/genai/Common.java
@@ -19,6 +19,7 @@ package com.google.genai;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.genai.errors.GenAiIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -27,13 +28,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
-import com.google.genai.errors.GenAiIOException;
 
 /** Common utility methods for the GenAI SDK. */
 final class Common {
 
   private Common() {}
+
+  private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("\\{([^}]+)\\}");
 
   /**
    * Sets the value of an object by a path.
@@ -161,7 +165,8 @@ final class Common {
       } else {
         if (currentObject.isObject() && ((ObjectNode) currentObject).has(key)) {
           currentObject = ((ObjectNode) currentObject).get(key);
-        } else {
+        }
+        else {
           return null;
         }
       }
@@ -171,20 +176,30 @@ final class Common {
   }
 
   static String formatMap(String template, JsonNode data) {
-    if (data == null) {
+    if (data == null || !data.isObject()) {
       return template;
     }
 
-    Iterator<Map.Entry<String, JsonNode>> fields = data.fields();
-    while (fields.hasNext()) {
-      Map.Entry<String, JsonNode> field = fields.next();
-      String key = field.getKey();
-      String placeholder = "{" + key + "}";
-      if (template.contains(placeholder)) {
-        template = template.replace(placeholder, data.get(key).asText());
+    System.out.println("Template " + template);
+    System.out.println("Data " + data);
+
+    Matcher matcher = PLACEHOLDER_PATTERN.matcher(template);
+    StringBuffer resultBuffer = new StringBuffer();
+
+    while (matcher.find()) {
+      String key = matcher.group(1);
+      // JsonNode valueNode = data.get(key);
+      JsonNode valueNode = data.path(key);
+
+      if (valueNode != null && valueNode.isValueNode()) {
+        String replacement = valueNode.asText();
+        matcher.appendReplacement(resultBuffer, Matcher.quoteReplacement(replacement));
       }
     }
-    return template;
+    matcher.appendTail(resultBuffer);
+
+    System.out.println("Template " + template);
+    return resultBuffer.toString();
   }
 
   static boolean isZero(Object obj) {

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/jni-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/jni-config.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "sun.management.VMManagementImpl",
+    "fields": [
+      {
+        "name": "compTimeMonitoringSupport"
+      },
+      {
+        "name": "currentThreadCpuTimeSupport"
+      },
+      {
+        "name": "objectMonitorUsageSupport"
+      },
+      {
+        "name": "otherThreadCpuTimeSupport"
+      },
+      {
+        "name": "remoteDiagnosticCommandsSupport"
+      },
+      {
+        "name": "synchronizerUsageSupport"
+      },
+      {
+        "name": "threadAllocatedMemorySupport"
+      },
+      {
+        "name": "threadContentionMonitoringSupport"
+      }
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=org.junit.platform.commons.util.LruCache,org.mockito,net.bytebuddy,org.objenesis

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-build-time=org.junit.platform.commons.util.LruCache,org.mockito,net.bytebuddy,org.objenesis
+Args = --initialize-at-build-time=org.junit.platform.commons.util.LruCache,org.mockito,net.bytebuddy,org.objenesis,com.google.genai.Client

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/proxy-config.json
@@ -1,0 +1,3 @@
+[
+  ["org.mockito.plugins.MockMaker", "org.mockito.invocation.MockHandler"]
+]

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/proxy-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/proxy-config.json
@@ -1,3 +1,97 @@
 [
-  ["org.mockito.plugins.MockMaker", "org.mockito.invocation.MockHandler"]
+  {
+    "interfaces": [
+      "net.bytebuddy.description.method.MethodDescription$InDefinedShape$AbstractBase$Executable"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.method.ParameterDescription$ForLoadedParameter$Parameter"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.method.ParameterList$ForLoadedExecutable$Executable"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDefinition$Sort$AnnotatedType"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$ForLoadedType$Dispatcher"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedExecutableExceptionType$Dispatcher"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedExecutableParameterType$Dispatcher"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedMethodReturnType$Dispatcher"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForComponentType$AnnotatedParameterizedType"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeArgument$AnnotatedParameterizedType"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeVariableBoundType$AnnotatedTypeVariable"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeVariableBoundType$OfFormalTypeVariable$FormalTypeVariable"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForWildcardLowerBoundType$AnnotatedWildcardType"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForWildcardUpperBoundType$AnnotatedWildcardType"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup$MethodHandles"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup$MethodHandles$Lookup"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$System"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.utility.JavaModule$Module"
+    ]
+  },
+  {
+    "interfaces": [
+      "net.bytebuddy.utility.JavaModule$Resolver"
+    ]
+  }
 ]

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
@@ -1,0 +1,12667 @@
+[
+  {
+    "name": "com.fasterxml.jackson.databind.node.ObjectNode",
+    "allDeclaredConstructors": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.JsonNode",
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.node.ObjectNode",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.node.ArrayNode",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "com.fasterxml.jackson.databind.node.TextNode",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.apache.http.client.methods.HttpPost",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.apache.http.client.methods.HttpGet",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.apache.http.impl.client.CloseableHttpClient",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.apache.http.impl.client.HttpClientBuilder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Content",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Content",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Part",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Part",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.Models",
+    "methods": [
+      {
+        "name": "generateContentResponseFromVertex",
+        "parameterTypes": [
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.fasterxml.jackson.databind.node.ObjectNode"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Candidate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Candidate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CitationMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CitationMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponse$PromptFeedback",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponse_PromptFeedback",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SafetyRating",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyRating",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponseUsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponseUsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponseUsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponseUsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ModalityTokenCount",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModalityTokenCount",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ModalityTokenCount$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModalityTokenCount$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponsePromptFeedback$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponsePromptFeedback$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SafetyRating$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyRating$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Candidate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Candidate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CitationMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CitationMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Citation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Citation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Citation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Citation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Content$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Content$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GoogleTypeDate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleTypeDate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GoogleTypeDate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleTypeDate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Part$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Part$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Blob",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Blob",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Blob$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Blob$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FileData",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileData",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FileData$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileData$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResultCandidate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResultCandidate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResultCandidate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResultCandidate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResultTopCandidates",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResultTopCandidates",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LogprobsResultTopCandidates$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LogprobsResultTopCandidates$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ExecutableCode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ExecutableCode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ExecutableCode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ExecutableCode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionCall",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCall",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionCall$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCall$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CodeExecutionResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CodeExecutionResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CodeExecutionResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CodeExecutionResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GroundingMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GroundingMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SafetyAttributes",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyAttributes",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SafetyAttributes$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyAttributes$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CodeExecutionResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CodeExecutionResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CodeExecutionResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CodeExecutionResult$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VideoMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VideoMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VideoMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VideoMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RetrievalMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RetrievalMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RetrievalMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RetrievalMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SearchEntryPoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SearchEntryPoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SearchEntryPoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SearchEntryPoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunk",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunk",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunk$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunk$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunkWeb",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunkWeb",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunkWeb$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunkWeb$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GroundingSupport",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingSupport",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GroundingSupport$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingSupport$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunkRetrievedContext",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunkRetrievedContext",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GroundingChunkRetrievedContext$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GroundingChunkRetrievedContext$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagChunk",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagChunk",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagChunk$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagChunk$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.JobState",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageAPIConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageAPIConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageAPIConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageAPIConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.InlinedResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_InlinedResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.InlinedResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_InlinedResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.PersonGeneration",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.JobError",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_JobError",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.JobError$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_JobError$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VideoCompressionQuality",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListBatchJobsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListBatchJobsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagChunkPageSpan",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagChunkPageSpan",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagChunkPageSpan$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagChunkPageSpan$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigFilter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigFilter",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigFilter$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigFilter$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigHybridSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigHybridSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigHybridSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigHybridSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRanking",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRanking",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRanking$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRanking$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRankingLlmRanker",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRankingLlmRanker",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRankingLlmRanker$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRankingLlmRanker$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRankingRankService",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRankingRankService",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RagRetrievalConfigRankingRankService$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RagRetrievalConfigRankingRankService$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Segment",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Segment",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Segment$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Segment$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveClientContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveClientContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveClientMessage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientMessage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveClientMessage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientMessage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveClientRealtimeInput",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientRealtimeInput",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveClientRealtimeInput$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientRealtimeInput$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveClientSetup",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientSetup",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveClientSetup$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientSetup$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveClientToolResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientToolResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveClientToolResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveClientToolResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectConstraints",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectConstraints",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectConstraints$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectConstraints$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveConnectParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConnectParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveConstrainedParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConstrainedParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveConstrainedParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveConstrainedParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveSendClientContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendClientContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveSendClientContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendClientContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveSendRealtimeInputParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendRealtimeInputParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveSendRealtimeInputParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendRealtimeInputParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveSendToolResponseParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendToolResponseParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveSendToolResponseParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveSendToolResponseParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerGoAway",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerGoAway",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerGoAway$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerGoAway$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerMessage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerMessage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerMessage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerMessage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerSessionResumptionUpdate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerSessionResumptionUpdate",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerSessionResumptionUpdate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerSessionResumptionUpdate$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerSetupComplete",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerSetupComplete",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerSetupComplete$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerSetupComplete$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerToolCall",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerToolCall",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerToolCall$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerToolCall$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LiveServerToolCallCancellation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerToolCallCancellation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LiveServerToolCallCancellation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LiveServerToolCallCancellation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UrlContext",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlContext",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UrlContext$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlContext$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UrlContextMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlContextMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UrlContextMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlContextMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UrlMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UrlMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UrlMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UrlRetrievalStatus",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ActivityEnd",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ActivityEnd$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityEnd",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityEnd$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ActivityHandling",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ActivityHandling$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityHandling",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityHandling$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ActivityStart",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ActivityStart$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityStart",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ActivityStart$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ApiKeyConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ApiKeyConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ApiKeyConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ApiKeyConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AudioTranscriptionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AudioTranscriptionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AudioTranscriptionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AudioTranscriptionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigGoogleServiceAccountConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigGoogleServiceAccountConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigGoogleServiceAccountConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigGoogleServiceAccountConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigHttpBasicAuthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigHttpBasicAuthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigHttpBasicAuthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigHttpBasicAuthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigOauthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigOauthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigOauthConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigOauthConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigOidcConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthConfigOidcConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigOidcConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthConfigOidcConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthToken",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthToken$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthToken",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthToken$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AuthType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AuthType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AuthType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutomaticActivityDetection",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutomaticActivityDetection$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AutomaticActivityDetection",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AutomaticActivityDetection$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutomaticFunctionCallingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutomaticFunctionCallingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AutomaticFunctionCallingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_AutomaticFunctionCallingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.BatchJob",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.BatchJob$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJob",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJob$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.BatchJobDestination",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.BatchJobDestination$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJobDestination",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJobDestination$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.BatchJobSource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.BatchJobSource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJobSource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BatchJobSource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Behavior",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Behavior$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Behavior",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Behavior$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.BlockedReason",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.BlockedReason$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BlockedReason",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_BlockedReason$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CachedContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CachedContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CachedContent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CachedContent$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CachedContentUsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CachedContentUsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CachedContentUsageMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CachedContentUsageMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CancelBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CancelBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CancelBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CancelBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CancelBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CancelBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CancelBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CancelBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Checkpoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Checkpoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Checkpoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Checkpoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ClientOptions",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ClientOptions$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ClientOptions",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ClientOptions$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ComputeTokensResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ComputeTokensResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ContentEmbedding",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ContentEmbedding$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContentEmbedding",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContentEmbedding$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ContentEmbeddingStatistics",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ContentEmbeddingStatistics$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContentEmbeddingStatistics",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContentEmbeddingStatistics$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ContextWindowCompressionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ContextWindowCompressionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContextWindowCompressionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ContextWindowCompressionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ControlReferenceType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ControlReferenceType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CountTokensConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CountTokensConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CountTokensParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CountTokensParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CountTokensResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CountTokensResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CountTokensResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateAuthTokenConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateAuthTokenConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateAuthTokenConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateAuthTokenConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateAuthTokenParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateAuthTokenParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateAuthTokenParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateAuthTokenParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.CreateFileResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.CreateFileResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_CreateFileResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteCachedContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteCachedContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteFileResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteFileResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DeleteModelResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DeleteModelResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DownloadFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DownloadFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DownloadFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DownloadFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DynamicRetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DynamicRetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DynamicRetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DynamicRetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.DynamicRetrievalConfigMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.DynamicRetrievalConfigMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DynamicRetrievalConfigMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_DynamicRetrievalConfigMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EditImageConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EditImageConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EditImageParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EditImageParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EditImageResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EditImageResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditImageResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EditMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EditMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EditMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentMetadata",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentMetadata$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EmbedContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EmbedContentResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EndSensitivity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EndSensitivity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EndSensitivity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EndSensitivity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Endpoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Endpoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Endpoint",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Endpoint$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.EnterpriseWebSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.EnterpriseWebSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EnterpriseWebSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_EnterpriseWebSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FeatureSelectionPreference",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FeatureSelectionPreference$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FeatureSelectionPreference",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FeatureSelectionPreference$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FetchPredictOperationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FetchPredictOperationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FetchPredictOperationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FetchPredictOperationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FetchPredictOperationParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FetchPredictOperationParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FetchPredictOperationParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FetchPredictOperationParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.File",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.File$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_File",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_File$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FileSource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FileSource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileSource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileSource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FileState",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FileState$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileState",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileState$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FileStatus",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FileStatus$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileStatus",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FileStatus$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FinishReason",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FinishReason$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FinishReason",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FinishReason$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionCallingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionCallingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCallingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCallingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionCallingConfigMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionCallingConfigMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCallingConfigMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionCallingConfigMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionDeclaration",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionDeclaration$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionDeclaration",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionDeclaration$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.FunctionResponseScheduling",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.FunctionResponseScheduling$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionResponseScheduling",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_FunctionResponseScheduling$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponsePromptFeedback",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateContentResponsePromptFeedback$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponsePromptFeedback",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponsePromptFeedback$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateImagesResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateImagesResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosOperation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosOperation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosOperation",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosOperation$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerateVideosResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerateVideosResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GeneratedImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GeneratedImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GeneratedImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GeneratedImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GeneratedVideo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GeneratedVideo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GeneratedVideo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GeneratedVideo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigAutoRoutingMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigAutoRoutingMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfigAutoRoutingMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfigAutoRoutingMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigManualRoutingMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigManualRoutingMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfigManualRoutingMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigRoutingConfigManualRoutingMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigThinkingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GenerationConfigThinkingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigThinkingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GenerationConfigThinkingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetBatchJobConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetBatchJobConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetBatchJobParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetBatchJobParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetFileParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetFileParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetOperationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetOperationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetOperationConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetOperationConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GetOperationParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GetOperationParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetOperationParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GetOperationParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GoogleMaps",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GoogleMaps$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleMaps",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleMaps$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GoogleSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GoogleSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleSearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleSearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.GoogleSearchRetrieval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.GoogleSearchRetrieval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleSearchRetrieval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_GoogleSearchRetrieval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HarmBlockMethod",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HarmBlockMethod$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmBlockMethod",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmBlockMethod$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HarmBlockThreshold",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HarmBlockThreshold$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmBlockThreshold",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmBlockThreshold$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HarmCategory",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HarmCategory$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmCategory",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmCategory$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HarmProbability",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HarmProbability$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmProbability",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmProbability$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HarmSeverity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HarmSeverity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmSeverity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HarmSeverity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HttpOptions",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HttpOptions$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HttpOptions",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HttpOptions$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.HttpResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.HttpResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HttpResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HttpResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Image",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Image$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Image",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Image$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ImagePromptLanguage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ImagePromptLanguage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ImagePromptLanguage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ImagePromptLanguage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.InlinedRequest",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.InlinedRequest$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_InlinedRequest",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_InlinedRequest$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Interval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Interval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Interval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Interval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Language",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Language$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Language",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Language$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.LatLng",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.LatLng$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LatLng",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_LatLng$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListCachedContentsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListCachedContentsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListFilesConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListFilesConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListFilesParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListFilesParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListFilesResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListFilesResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListFilesResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListModelsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListModelsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListModelsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListModelsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ListModelsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ListModelsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ListModelsResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MaskReferenceMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceMode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MaskReferenceMode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MediaModality",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MediaModality$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MediaModality",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MediaModality$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MediaResolution",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MediaResolution$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MediaResolution",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MediaResolution$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Modality",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Modality$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Modality",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Modality$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Mode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Mode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Mode",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Mode$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Model",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Model$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Model",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Model$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ModelRoutingPreference",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ModelRoutingPreference$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModelRoutingPreference",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModelRoutingPreference$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ModelSelectionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ModelSelectionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModelSelectionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ModelSelectionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.MultiSpeakerVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.MultiSpeakerVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MultiSpeakerVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_MultiSpeakerVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Outcome",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Outcome$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Outcome",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Outcome$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.PrebuiltVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.PrebuiltVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_PrebuiltVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_PrebuiltVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ProactivityConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ProactivityConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ProactivityConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ProactivityConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RawReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RawReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RawReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RawReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RealtimeInputConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RealtimeInputConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RealtimeInputConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RealtimeInputConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReferenceImageAPI",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReferenceImageAPI$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReferenceImageAPI",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReferenceImageAPI$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReplayFile",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReplayFile$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayFile",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayFile$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReplayInteraction",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReplayInteraction$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayInteraction",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayInteraction$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReplayRequest",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReplayRequest$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayRequest",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayRequest$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ReplayResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ReplayResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ReplayResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Retrieval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Retrieval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Retrieval",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Retrieval$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.RetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.RetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RetrievalConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_RetrievalConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SafetyFilterLevel",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SafetyFilterLevel$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyFilterLevel",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetyFilterLevel$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SafetySetting",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SafetySetting$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetySetting",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SafetySetting$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Schema",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Schema$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Schema",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Schema$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SessionResumptionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SessionResumptionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SessionResumptionConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SessionResumptionConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SlidingWindow",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SlidingWindow$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SlidingWindow",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SlidingWindow$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SpeakerVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SpeakerVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SpeakerVoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SpeakerVoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SpeechConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SpeechConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SpeechConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SpeechConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.StartSensitivity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.StartSensitivity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StartSensitivity",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StartSensitivity$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.StyleReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.StyleReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StyleReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StyleReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.StyleReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.StyleReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StyleReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_StyleReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceImage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceImage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.SubjectReferenceType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_SubjectReferenceType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TestTableFile",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TestTableFile$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TestTableFile",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TestTableFile$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TestTableItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TestTableItem$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TestTableItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TestTableItem$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ThinkingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ThinkingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ThinkingConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ThinkingConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TokensInfo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TokensInfo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TokensInfo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TokensInfo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Tool",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Tool$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Tool",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Tool$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ToolCodeExecution",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ToolCodeExecution$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ToolCodeExecution",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ToolCodeExecution$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.ToolConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.ToolConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ToolConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_ToolConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TrafficType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TrafficType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TrafficType",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TrafficType$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Transcription",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Transcription$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Transcription",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Transcription$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TunedModelInfo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TunedModelInfo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TunedModelInfo",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TunedModelInfo$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.TurnCoverage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.TurnCoverage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TurnCoverage",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_TurnCoverage$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Type",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Type$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Type",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Type$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpdateCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpdateCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateCachedContentConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateCachedContentConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpdateCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpdateCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateCachedContentParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateCachedContentParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpdateModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpdateModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateModelConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateModelConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpdateModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpdateModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateModelParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpdateModelParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UploadFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UploadFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UploadFileConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UploadFileConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageAPIParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageAPIParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageAPIParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageAPIParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageParameters",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageParameters$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.UpscaleImageResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_UpscaleImageResponse$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VertexAISearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VertexAISearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexAISearch",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexAISearch$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VertexAISearchDataStoreSpec",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VertexAISearchDataStoreSpec$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexAISearchDataStoreSpec",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexAISearchDataStoreSpec$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VertexRagStore",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VertexRagStore$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexRagStore",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexRagStore$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VertexRagStoreRagResource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VertexRagStoreRagResource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexRagStoreRagResource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VertexRagStoreRagResource$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.Video",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.Video$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Video",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_Video$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.VoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.VoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VoiceConfig",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_VoiceConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredFields": true,
+    "allPublicFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
@@ -12663,5 +12663,5132 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "name": "[B"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.deser.Deserializers;"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.deser.KeyDeserializers;"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.deser.ValueInstantiators;"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.ser.BeanSerializerModifier;"
+  },
+  {
+    "name": "[Lcom.fasterxml.jackson.databind.ser.Serializers;"
+  },
+  {
+    "name": "[Lcom.google.common.collect.ImmutableMapEntry;"
+  },
+  {
+    "name": "[Ljava.lang.Object;"
+  },
+  {
+    "name": "[Ljava.util.HashMap$Node;"
+  },
+  {
+    "name": "[Ljava.util.Map$Entry;"
+  },
+  {
+    "name": "[Lorg.eclipse.jetty.server.Handler;"
+  },
+  {
+    "name": "[Lorg.eclipse.jetty.servlet.ServletMapping;"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.fasterxml.jackson.databind.ext.Java7SupportImpl"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.FindStubMappingsByMetadataTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.GetAllScenariosTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.GetGlobalSettingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.GetRecordingStatusTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.ImportStubMappingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.PatchExtendedSettingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.RemoveServeEventTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.RemoveServeEventsByRequestPatternTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.RemoveServeEventsByStubMetadataTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.RemoveStubMappingsByMetadataTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.SetScenarioStateTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.StartRecordingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.StopRecordingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.CreateStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.DeleteStubFileTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.EditStubFileTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.EditStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.FindNearMissesForRequestPatternTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.FindNearMissesForRequestTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.FindNearMissesForUnmatchedTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.FindRequestsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.FindUnmatchedRequestsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetAllRequestsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetAllStubFilesTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetAllStubMappingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetCaCertTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetDocIndexTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetRecordingsIndexTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetRequestCountTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetServedStubTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GetSwaggerSpecTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.GlobalSettingsUpdateTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.OldCreateStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.OldEditStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.OldRemoveStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.OldResetRequestsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.RemoveStubMappingTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ResetRequestsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ResetScenariosTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ResetStubMappingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ResetTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ResetToDefaultMappingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.RootRedirectTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.RootTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.SaveMappingsTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.ShutdownServerTask"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.admin.tasks.SnapshotTask"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.client.BasicCredentials"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.common.Metadata"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.extension.Parameters"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.http.ChunkedDribbleDelay"
+  },
+  {
+    "name": "com.github.tomakehurst.wiremock.http.DelayDistribution"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.http.Fault"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.http.HttpHeadersJsonDeserializer"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.http.HttpHeadersJsonSerializer"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "fromString",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.http.RequestMethod"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "java.lang.String",
+          "java.lang.String",
+          "com.fasterxml.jackson.databind.JsonNode",
+          "java.lang.String",
+          "java.lang.String",
+          "com.github.tomakehurst.wiremock.http.HttpHeaders",
+          "com.github.tomakehurst.wiremock.http.HttpHeaders",
+          "java.lang.Integer",
+          "com.github.tomakehurst.wiremock.http.DelayDistribution",
+          "com.github.tomakehurst.wiremock.http.ChunkedDribbleDelay",
+          "java.lang.String",
+          "java.lang.String",
+          "com.github.tomakehurst.wiremock.http.Fault",
+          "java.util.List",
+          "com.github.tomakehurst.wiremock.extension.Parameters",
+          "java.lang.Boolean"
+        ]
+      },
+      {
+        "name": "getAdditionalProxyRequestHeaders",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBase64Body",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBody",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBodyFileName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getChunkedDribbleDelay",
+        "parameterTypes": []
+      },
+      {
+        "name": "getDelayDistribution",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFault",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFixedDelayMilliseconds",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHeaders",
+        "parameterTypes": []
+      },
+      {
+        "name": "getJsonBody",
+        "parameterTypes": []
+      },
+      {
+        "name": "getProxyBaseUrl",
+        "parameterTypes": []
+      },
+      {
+        "name": "getProxyUrlPrefixToRemove",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStatus",
+        "parameterTypes": []
+      },
+      {
+        "name": "getStatusMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTransformerParameters",
+        "parameterTypes": []
+      },
+      {
+        "name": "getTransformers",
+        "parameterTypes": []
+      },
+      {
+        "name": "isFromConfiguredStub",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.http.ResponseDefinition"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "com.github.tomakehurst.wiremock.core.Options",
+          "com.github.tomakehurst.wiremock.http.AdminRequestHandler",
+          "com.github.tomakehurst.wiremock.http.StubRequestHandler"
+        ]
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.jetty94.Jetty94HttpServer"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String",
+          "char[]"
+        ]
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.jetty94.WritableFileOrClasspathKeyStoreSource"
+  },
+  {
+    "name": "com.github.tomakehurst.wiremock.matching.AnythingPattern"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.matching.ContentPatternDeserialiser"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.matching.CustomMatcherDefinition"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.matching.MultiValuePattern"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.matching.MultipartValuePattern"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.github.tomakehurst.wiremock.matching.MultipartValuePattern$MatchingType"
+  },
+  {
+    "name": "com.github.tomakehurst.wiremock.matching.NamedValueMatcher"
+  },
+  {
+    "name": "com.github.tomakehurst.wiremock.matching.RegexPattern"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String",
+          "com.github.tomakehurst.wiremock.matching.StringValuePattern",
+          "java.lang.Integer",
+          "java.lang.String",
+          "java.lang.String",
+          "java.lang.String",
+          "java.lang.String",
+          "com.github.tomakehurst.wiremock.http.RequestMethod",
+          "java.util.Map",
+          "java.util.Map",
+          "java.util.Map",
+          "com.github.tomakehurst.wiremock.client.BasicCredentials",
+          "java.util.List",
+          "com.github.tomakehurst.wiremock.matching.CustomMatcherDefinition",
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "getBasicAuthCredentials",
+        "parameterTypes": []
+      },
+      {
+        "name": "getBodyPatterns",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCookies",
+        "parameterTypes": []
+      },
+      {
+        "name": "getCustomMatcher",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHeaders",
+        "parameterTypes": []
+      },
+      {
+        "name": "getHost",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMethod",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMultipartPatterns",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPort",
+        "parameterTypes": []
+      },
+      {
+        "name": "getQueryParameters",
+        "parameterTypes": []
+      },
+      {
+        "name": "getScheme",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUrl",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUrlPath",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUrlPathPattern",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUrlPattern",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.matching.RequestPattern"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.matching.StringValuePatternJsonDeserializer"
+  },
+  {
+    "name": "com.github.tomakehurst.wiremock.matching.ValueMatcher"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.servlet.ContentTypeSettingFilter"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.servlet.TrailingSlashFilter"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getId",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMetadata",
+        "parameterTypes": []
+      },
+      {
+        "name": "getName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getNewScenarioState",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPostServeActions",
+        "parameterTypes": []
+      },
+      {
+        "name": "getPriority",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRequest",
+        "parameterTypes": []
+      },
+      {
+        "name": "getRequiredScenarioState",
+        "parameterTypes": []
+      },
+      {
+        "name": "getResponse",
+        "parameterTypes": []
+      },
+      {
+        "name": "getScenarioName",
+        "parameterTypes": []
+      },
+      {
+        "name": "getUuid",
+        "parameterTypes": []
+      },
+      {
+        "name": "isPersistent",
+        "parameterTypes": []
+      },
+      {
+        "name": "setId",
+        "parameterTypes": [
+          "java.util.UUID"
+        ]
+      },
+      {
+        "name": "setRequest",
+        "parameterTypes": [
+          "com.github.tomakehurst.wiremock.matching.RequestPattern"
+        ]
+      },
+      {
+        "name": "setResponse",
+        "parameterTypes": [
+          "com.github.tomakehurst.wiremock.http.ResponseDefinition"
+        ]
+      },
+      {
+        "name": "setUuid",
+        "parameterTypes": [
+          "java.util.UUID"
+        ]
+      }
+    ],
+    "name": "com.github.tomakehurst.wiremock.stubbing.StubMapping"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.api.client.json.GenericJson"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.api.client.util.GenericData"
+  },
+  {
+    "name": "com.google.auth.Credentials"
+  },
+  {
+    "name": "com.google.auth.oauth2.GoogleCredentials"
+  },
+  {
+    "name": "com.google.auth.oauth2.OAuth2Credentials"
+  },
+  {
+    "name": "com.google.auth.oauth2.QuotaProjectIdProvider"
+  },
+  {
+    "name": "com.google.common.collect.BiMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.ImmutableBiMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.ImmutableCollection"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.ImmutableList"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.ImmutableMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.RegularImmutableMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.SingletonImmutableBiMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.common.collect.SingletonImmutableList"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionMap_emptyConfig_returnsEmptyFunctionMap",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionMap_nullConfig_returnsEmptyFunctionMap",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionMap_returnsFunctionMap",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionResponseParts_emptyFunctionCall_returnsEmptyFunctionResponseParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionResponseParts_emptyFunctionMap_returnsEmptyFunctionResponseParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionResponseParts_emptyResponse_returnsEmptyFunctionResponseParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionResponseParts_exceptionThrown_returnsFunctionResponseParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getFunctionResponseParts_returnsFunctionResponseParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxRemoteCallsAfc_emptyConfig_returnsDefaultMaxRemoteCallsAfc",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxRemoteCallsAfc_emptyMaxRemoteCalls_returnsDefaultMaxRemoteCallsAfc",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxRemoteCallsAfc_nullConfig_returnsDefaultMaxRemoteCallsAfc",
+        "parameterTypes": []
+      },
+      {
+        "name": "getMaxRemoteCallsAfc_returnsMaxRemoteCallsAfc",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasCallableTool_emptyTools_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasCallableTool_noFunctions_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasCallableTool_nullConfig_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "hasCallableTool_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldAppendAfcHistory_emptyConfig_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldAppendAfcHistory_ignoreCallHistory_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldAppendAfcHistory_nullConfig_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldDisableAfc_disableAfcAndMaxRemoteCalls_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldDisableAfc_disableAfc_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldDisableAfc_emptyConfig_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldDisableAfc_enableAfcMaxRemoteCallsNegative_returnsTrue",
+        "parameterTypes": []
+      },
+      {
+        "name": "shouldDisableAfc_nullConfig_returnsFalse",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFunction1",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "testFunction2",
+        "parameterTypes": [
+          "java.lang.Integer",
+          "java.lang.Integer"
+        ]
+      },
+      {
+        "name": "transformGenerateContentConfig_emptyConfig_returnsTransformedConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "transformGenerateContentConfig_functionDeclarationAndMethod_returnsTransformedConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "transformGenerateContentConfig_functionDeclaration_returnsTransformedConfig",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.AfcUtilTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.ApiClient"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.ApiClient$MockitoMock$1803701717"
+  },
+  {
+    "name": "com.google.genai.ApiResponse"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setUp",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCreateAsyncChatSession",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetAsyncChatMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetHistoryAsync",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIterateOverAsyncResponseStream",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowsIfAsyncStreamResponseIsNotConsumed",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.AsyncChatTest"
+  },
+  {
+    "fields": [
+      {
+        "name": "apiClient"
+      }
+    ],
+    "name": "com.google.genai.AsyncChats"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "findTheaters",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setUp",
+        "parameterTypes": []
+      },
+      {
+        "name": "testChatWithConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCreateChatSession",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetHistory",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetHistoryWithAfc",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitConfigIsUsedWhenSendMessageConfigIsNull",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInvalidHistoryThrows",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInvalidRoleThrows",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIterateOverResponseStream",
+        "parameterTypes": []
+      },
+      {
+        "name": "testMultiTurnChat",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSendMessageContent",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSendMessageContentList",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowsIfStreamResponseIsNotConsumed",
+        "parameterTypes": []
+      },
+      {
+        "name": "testUnexpectedFinishReasonDoesNotAddToCuratedHistory",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.ChatTest"
+  },
+  {
+    "fields": [
+      {
+        "name": "apiClient"
+      }
+    ],
+    "name": "com.google.genai.Chats"
+  },
+  {
+    "fields": [
+      {
+        "name": "apiClient"
+      }
+    ],
+    "name": "com.google.genai.Client"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCloseClient",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCloseClient_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_mldev",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_setApiKeyInVertex_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_setBothApiKeyAndProject_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_setProjectInMldev_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_vertex",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitClientFromBuilder_withCredentialsAndHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testReplayClient_mldev",
+        "parameterTypes": []
+      },
+      {
+        "name": "testReplayClient_vertex",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSetDefaultBaseUrls",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.ClientTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFormatMap_emptyData",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFormatMap_missingKey",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFormatMap_nonValueNode",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFormatMap_simple",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_arrayObject",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_firstArrayElement",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_notFound",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_nullKeys",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_nullObject",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_self",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetValueByPath_simpleObject",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_boolean_false",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_boolean_true",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_character_nonzero",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_character_zero",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_null",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_number_nonzero",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_number_zero",
+        "parameterTypes": []
+      },
+      {
+        "name": "testIsZero_otherObject",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSetValueByPath_arrayObject",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSetValueByPath_arrayObject_existing",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSetValueByPath_firstArrayElement",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSetValueByPath_simpleObject",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.CommonTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testDefaultValues",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.DefaultValuesTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setUp",
+        "parameterTypes": []
+      },
+      {
+        "name": "testEnumForwardCompatibilityFinishReason",
+        "parameterTypes": []
+      },
+      {
+        "name": "testEnumForwardCompatibilitySafetyFilterLevel",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFinishReasonEnumReturnsEnum",
+        "parameterTypes": []
+      },
+      {
+        "name": "testForwardCompatibility",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInlineEnum",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.ForwardCompatibilityTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testClientInitializationWithBaseUrlFromEnvironment",
+        "parameterTypes": []
+      },
+      {
+        "name": "testClientInitializationWithBaseUrlFromHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testClientInitializationWithBaseUrlFromHttpOptionsOverridesSetDefaultBaseUrls",
+        "parameterTypes": []
+      },
+      {
+        "name": "testClientInitializationWithBaseUrlFromSetBaseUrls",
+        "parameterTypes": []
+      },
+      {
+        "name": "testClientInitializationWithBaseUrlFromSetBaseUrlsOverridesEnvironment",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientMLDevTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientMLDevWithNoHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientMldevCustomClientOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientMldevDefaultClientOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientNoTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientVertexCustomClientOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientVertexNoTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientVertexTimeout",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientVertexWithGlobalEndpoint",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientVertexWithNoHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testHttpClientWithCustomCredentials",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitHttpClientMldev",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitHttpClientMldevWithPartialHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitHttpClientVertex",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitHttpClientVertexWithPartialHttpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "testProxySetup",
+        "parameterTypes": []
+      },
+      {
+        "name": "testRequestDeleteMethodWithMldev",
+        "parameterTypes": []
+      },
+      {
+        "name": "testRequestGetMethodWithMldev",
+        "parameterTypes": []
+      },
+      {
+        "name": "testRequestPostMethodWithVertexAI",
+        "parameterTypes": []
+      },
+      {
+        "name": "testRequestWithHttpOptions",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.HttpApiClientTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.JsonSerializable"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testLiveSendRealtimeInputParameters_Audio_okay",
+        "parameterTypes": []
+      },
+      {
+        "name": "testLiveSendRealtimeInputParameters_BadBlob_throws",
+        "parameterTypes": []
+      },
+      {
+        "name": "testLiveSendRealtimeInputParameters_Media_wrapped",
+        "parameterTypes": []
+      },
+      {
+        "name": "testLiveSendRealtimeInputParameters_Text_okay",
+        "parameterTypes": []
+      },
+      {
+        "name": "testMultiSpeakerVoiceConfig_throws",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.LiveConvertersTest"
+  },
+  {
+    "fields": [
+      {
+        "name": "apiClient"
+      }
+    ],
+    "methods": [
+      {
+        "name": "generateContentResponseFromMldev",
+        "parameterTypes": [
+          "com.fasterxml.jackson.databind.JsonNode",
+          "com.fasterxml.jackson.databind.node.ObjectNode"
+        ]
+      }
+    ],
+    "name": "com.google.genai.Models"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.ModelsTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.OperationsTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPathNameMismatch",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPathTypeMismatch",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSanitizeSuccess",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.ReplaySanitizerTest"
+  },
+  {
+    "name": "com.google.genai.ResponseStream$ResponseStreamIterator"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.TableTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_noModels_returnEmptyArrayNode",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_nullResponse_returnNull",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_responseWithModels",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_responseWithPublisherModels",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_responseWithTunedModels",
+        "parameterTypes": []
+      },
+      {
+        "name": "tExtractModels_unsupportedType_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_file_noName_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_generatedVideo_noUri_returnNull",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_generatedVideo_noVideo_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_generatedVideo_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_string_file_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_string_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_textNode_file_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_unsupportedType_throwsException",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_video_noUri_returnNull",
+        "parameterTypes": []
+      },
+      {
+        "name": "tFileName_video_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_AnyOf_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_GeminiAPI_defaultValue_noChange",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_GeminiAPI_title_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_Items_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_Required_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTSchema_VertexAI_defaultValue_noChange",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTTool_Functions_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTTool_functionsEmpty_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "testTTool_noFunctions_success",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.TransformersTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "setUp",
+        "parameterTypes": []
+      },
+      {
+        "name": "tearDown",
+        "parameterTypes": []
+      },
+      {
+        "name": "upload_bytes_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "upload_file_retries_exhausted_throws",
+        "parameterTypes": []
+      },
+      {
+        "name": "upload_file_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "upload_file_with_retriable_error_success",
+        "parameterTypes": []
+      },
+      {
+        "name": "upload_stream_success",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.UploadClientTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_EmptyBody",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_InvalidJson",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_MessageNotText",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_NoErrorNode",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_NoMessageNode",
+        "parameterTypes": []
+      },
+      {
+        "name": "testGetErrorMessage_ValidMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowFromResponse_ClientError_ThrowsClientException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowFromResponse_OKStatus_DoesNotThrow",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowFromResponse_OtherError_ThrowsApiException",
+        "parameterTypes": []
+      },
+      {
+        "name": "testThrowFromResponse_ServerError_ThrowsServerException",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.errors.ApiExceptionTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitGenAiIOException_withCause",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitGenAiIOException_withMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "testInitGenAiIOException_withMessageAndCause",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.errors.GenAiIOExceptionTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ApiKeyConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthConfigGoogleServiceAccountConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthConfigHttpBasicAuthConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthConfigOauthConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthConfigOidcConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AuthType"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "data",
+        "parameterTypes": []
+      },
+      {
+        "name": "displayName",
+        "parameterTypes": []
+      },
+      {
+        "name": "mimeType",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Blob"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "avgLogprobs",
+        "parameterTypes": []
+      },
+      {
+        "name": "citationMetadata",
+        "parameterTypes": []
+      },
+      {
+        "name": "content",
+        "parameterTypes": []
+      },
+      {
+        "name": "finishMessage",
+        "parameterTypes": []
+      },
+      {
+        "name": "finishReason",
+        "parameterTypes": []
+      },
+      {
+        "name": "groundingMetadata",
+        "parameterTypes": []
+      },
+      {
+        "name": "index",
+        "parameterTypes": []
+      },
+      {
+        "name": "logprobsResult",
+        "parameterTypes": []
+      },
+      {
+        "name": "safetyRatings",
+        "parameterTypes": []
+      },
+      {
+        "name": "tokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "urlContextMetadata",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Candidate"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "parts",
+        "parameterTypes": []
+      },
+      {
+        "name": "role",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Content"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "contents",
+        "parameterTypes": []
+      },
+      {
+        "name": "displayName",
+        "parameterTypes": []
+      },
+      {
+        "name": "expireTime",
+        "parameterTypes": []
+      },
+      {
+        "name": "httpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "kmsKeyName",
+        "parameterTypes": []
+      },
+      {
+        "name": "systemInstruction",
+        "parameterTypes": []
+      },
+      {
+        "name": "toolConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "tools",
+        "parameterTypes": []
+      },
+      {
+        "name": "ttl",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_CreateCachedContentConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "args",
+        "parameterTypes": []
+      },
+      {
+        "name": "id",
+        "parameterTypes": []
+      },
+      {
+        "name": "name",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_FunctionCall"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "behavior",
+        "parameterTypes": []
+      },
+      {
+        "name": "description",
+        "parameterTypes": []
+      },
+      {
+        "name": "name",
+        "parameterTypes": []
+      },
+      {
+        "name": "parameters",
+        "parameterTypes": []
+      },
+      {
+        "name": "parametersJsonSchema",
+        "parameterTypes": []
+      },
+      {
+        "name": "response",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseJsonSchema",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_FunctionDeclaration"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "id",
+        "parameterTypes": []
+      },
+      {
+        "name": "name",
+        "parameterTypes": []
+      },
+      {
+        "name": "response",
+        "parameterTypes": []
+      },
+      {
+        "name": "scheduling",
+        "parameterTypes": []
+      },
+      {
+        "name": "willContinue",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_FunctionResponse"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "audioTimestamp",
+        "parameterTypes": []
+      },
+      {
+        "name": "automaticFunctionCalling",
+        "parameterTypes": []
+      },
+      {
+        "name": "cachedContent",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidateCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "frequencyPenalty",
+        "parameterTypes": []
+      },
+      {
+        "name": "httpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "labels",
+        "parameterTypes": []
+      },
+      {
+        "name": "logprobs",
+        "parameterTypes": []
+      },
+      {
+        "name": "maxOutputTokens",
+        "parameterTypes": []
+      },
+      {
+        "name": "mediaResolution",
+        "parameterTypes": []
+      },
+      {
+        "name": "modelSelectionConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "presencePenalty",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseJsonSchema",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseLogprobs",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseMimeType",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseModalities",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseSchema",
+        "parameterTypes": []
+      },
+      {
+        "name": "routingConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "safetySettings",
+        "parameterTypes": []
+      },
+      {
+        "name": "seed",
+        "parameterTypes": []
+      },
+      {
+        "name": "speechConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "stopSequences",
+        "parameterTypes": []
+      },
+      {
+        "name": "systemInstruction",
+        "parameterTypes": []
+      },
+      {
+        "name": "temperature",
+        "parameterTypes": []
+      },
+      {
+        "name": "thinkingConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "toolConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "tools",
+        "parameterTypes": []
+      },
+      {
+        "name": "topK",
+        "parameterTypes": []
+      },
+      {
+        "name": "topP",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_GenerateContentConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "config",
+        "parameterTypes": []
+      },
+      {
+        "name": "contents",
+        "parameterTypes": []
+      },
+      {
+        "name": "model",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_GenerateContentParameters"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "automaticFunctionCallingHistory",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "createTime",
+        "parameterTypes": []
+      },
+      {
+        "name": "modelVersion",
+        "parameterTypes": []
+      },
+      {
+        "name": "promptFeedback",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseId",
+        "parameterTypes": []
+      },
+      {
+        "name": "usageMetadata",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponse"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "cacheTokensDetails",
+        "parameterTypes": []
+      },
+      {
+        "name": "cachedContentTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidatesTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidatesTokensDetails",
+        "parameterTypes": []
+      },
+      {
+        "name": "promptTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "promptTokensDetails",
+        "parameterTypes": []
+      },
+      {
+        "name": "thoughtsTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "toolUsePromptTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "toolUsePromptTokensDetails",
+        "parameterTypes": []
+      },
+      {
+        "name": "totalTokenCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "trafficType",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_GenerateContentResponseUsageMetadata"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "timeRangeFilter",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_GoogleSearch"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "clientContent",
+        "parameterTypes": []
+      },
+      {
+        "name": "realtimeInput",
+        "parameterTypes": []
+      },
+      {
+        "name": "realtimeInputParameters",
+        "parameterTypes": []
+      },
+      {
+        "name": "setup",
+        "parameterTypes": []
+      },
+      {
+        "name": "toolResponse",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_LiveClientMessage"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "contextWindowCompression",
+        "parameterTypes": []
+      },
+      {
+        "name": "enableAffectiveDialog",
+        "parameterTypes": []
+      },
+      {
+        "name": "httpOptions",
+        "parameterTypes": []
+      },
+      {
+        "name": "inputAudioTranscription",
+        "parameterTypes": []
+      },
+      {
+        "name": "maxOutputTokens",
+        "parameterTypes": []
+      },
+      {
+        "name": "mediaResolution",
+        "parameterTypes": []
+      },
+      {
+        "name": "outputAudioTranscription",
+        "parameterTypes": []
+      },
+      {
+        "name": "proactivity",
+        "parameterTypes": []
+      },
+      {
+        "name": "realtimeInputConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "responseModalities",
+        "parameterTypes": []
+      },
+      {
+        "name": "seed",
+        "parameterTypes": []
+      },
+      {
+        "name": "sessionResumption",
+        "parameterTypes": []
+      },
+      {
+        "name": "speechConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "systemInstruction",
+        "parameterTypes": []
+      },
+      {
+        "name": "temperature",
+        "parameterTypes": []
+      },
+      {
+        "name": "tools",
+        "parameterTypes": []
+      },
+      {
+        "name": "topK",
+        "parameterTypes": []
+      },
+      {
+        "name": "topP",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_LiveConnectConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "activityEnd",
+        "parameterTypes": []
+      },
+      {
+        "name": "activityStart",
+        "parameterTypes": []
+      },
+      {
+        "name": "audio",
+        "parameterTypes": []
+      },
+      {
+        "name": "audioStreamEnd",
+        "parameterTypes": []
+      },
+      {
+        "name": "media",
+        "parameterTypes": []
+      },
+      {
+        "name": "text",
+        "parameterTypes": []
+      },
+      {
+        "name": "video",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_LiveSendRealtimeInputParameters"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "speakerVoiceConfigs",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_MultiSpeakerVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "codeExecutionResult",
+        "parameterTypes": []
+      },
+      {
+        "name": "executableCode",
+        "parameterTypes": []
+      },
+      {
+        "name": "fileData",
+        "parameterTypes": []
+      },
+      {
+        "name": "functionCall",
+        "parameterTypes": []
+      },
+      {
+        "name": "functionResponse",
+        "parameterTypes": []
+      },
+      {
+        "name": "inlineData",
+        "parameterTypes": []
+      },
+      {
+        "name": "text",
+        "parameterTypes": []
+      },
+      {
+        "name": "thought",
+        "parameterTypes": []
+      },
+      {
+        "name": "thoughtSignature",
+        "parameterTypes": []
+      },
+      {
+        "name": "videoMetadata",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Part"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "voiceName",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_PrebuiltVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "anyOf",
+        "parameterTypes": []
+      },
+      {
+        "name": "default_",
+        "parameterTypes": []
+      },
+      {
+        "name": "description",
+        "parameterTypes": []
+      },
+      {
+        "name": "enum_",
+        "parameterTypes": []
+      },
+      {
+        "name": "example",
+        "parameterTypes": []
+      },
+      {
+        "name": "format",
+        "parameterTypes": []
+      },
+      {
+        "name": "items",
+        "parameterTypes": []
+      },
+      {
+        "name": "maxItems",
+        "parameterTypes": []
+      },
+      {
+        "name": "maxLength",
+        "parameterTypes": []
+      },
+      {
+        "name": "maxProperties",
+        "parameterTypes": []
+      },
+      {
+        "name": "maximum",
+        "parameterTypes": []
+      },
+      {
+        "name": "minItems",
+        "parameterTypes": []
+      },
+      {
+        "name": "minLength",
+        "parameterTypes": []
+      },
+      {
+        "name": "minProperties",
+        "parameterTypes": []
+      },
+      {
+        "name": "minimum",
+        "parameterTypes": []
+      },
+      {
+        "name": "nullable",
+        "parameterTypes": []
+      },
+      {
+        "name": "pattern",
+        "parameterTypes": []
+      },
+      {
+        "name": "properties",
+        "parameterTypes": []
+      },
+      {
+        "name": "propertyOrdering",
+        "parameterTypes": []
+      },
+      {
+        "name": "required",
+        "parameterTypes": []
+      },
+      {
+        "name": "title",
+        "parameterTypes": []
+      },
+      {
+        "name": "type",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Schema"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "speaker",
+        "parameterTypes": []
+      },
+      {
+        "name": "voiceConfig",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_SpeakerVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "languageCode",
+        "parameterTypes": []
+      },
+      {
+        "name": "multiSpeakerVoiceConfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "voiceConfig",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_SpeechConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "codeExecution",
+        "parameterTypes": []
+      },
+      {
+        "name": "enterpriseWebSearch",
+        "parameterTypes": []
+      },
+      {
+        "name": "functionDeclarations",
+        "parameterTypes": []
+      },
+      {
+        "name": "googleMaps",
+        "parameterTypes": []
+      },
+      {
+        "name": "googleSearch",
+        "parameterTypes": []
+      },
+      {
+        "name": "googleSearchRetrieval",
+        "parameterTypes": []
+      },
+      {
+        "name": "retrieval",
+        "parameterTypes": []
+      },
+      {
+        "name": "urlContext",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_Tool"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "endOffset",
+        "parameterTypes": []
+      },
+      {
+        "name": "fps",
+        "parameterTypes": []
+      },
+      {
+        "name": "startOffset",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_VideoMetadata"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "prebuiltVoiceConfig",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.AutoValue_VoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.AutomaticFunctionCallingConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Behavior"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Blob"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "data",
+        "parameterTypes": [
+          "byte[]"
+        ]
+      },
+      {
+        "name": "mimeType",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Blob$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.BlockedReason"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Candidate"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "content",
+        "parameterTypes": [
+          "com.google.genai.types.Content"
+        ]
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "finishReason",
+        "parameterTypes": [
+          "com.google.genai.types.FinishReason"
+        ]
+      },
+      {
+        "name": "safetyRatings",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Candidate$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Citation$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.CitationMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.CodeExecutionResult$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Content"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "parts",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "role",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Content$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testContentFromParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_ConcatenatesTextParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_EmptyParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_NoTextParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_NonTextParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_NullParts",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.ContentTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.CreateCachedContentConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "expireTime",
+        "parameterTypes": [
+          "java.time.Instant"
+        ]
+      },
+      {
+        "name": "ttl",
+        "parameterTypes": [
+          "java.time.Duration"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.CreateCachedContentConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSerializationDeserialization_nullFields",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSerializationDeserialization_withInstantAndDuration",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.CreateCachedContentConfigTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.DynamicRetrievalConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.DynamicRetrievalConfigMode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.EnterpriseWebSearch$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ExecutableCode$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FeatureSelectionPreference"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FileData$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.FinishReason"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionCall"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "args",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "name",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.FunctionCall$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionCallingConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionCallingConfigMode"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionDeclaration"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "description",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "name",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "parameters",
+        "parameterTypes": [
+          "com.google.genai.types.Schema"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.FunctionDeclaration$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromMethodWithInstanceMethod_throwsIllegalArgumentException",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromMethodWithInvalidParameterType_throwsIllegalArgumentException",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromMethodWithParameterNames_returnsFunctionDeclaration",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromMethodWithUnmatchedParameterNames_throwsIllegalArgumentException",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.FunctionDeclarationTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionResponse"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "name",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "response",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.FunctionResponse$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.FunctionResponseScheduling"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerateContentConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "tools",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.GenerateContentConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerateContentParameters"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerateContentResponse"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "automaticFunctionCallingHistory",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidates",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "usageMetadata",
+        "parameterTypes": [
+          "com.google.genai.types.GenerateContentResponseUsageMetadata"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.GenerateContentResponse$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerateContentResponsePromptFeedback$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_EmptyCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_EmptyContent",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_EmptyParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_MultipleCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_MultipleParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_PartWithCodeExecutionResult",
+        "parameterTypes": []
+      },
+      {
+        "name": "testCodeExecutionResult_TextPart",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_EmptyCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_EmptyContent",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_EmptyParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_MultipleCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_MultipleParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_PartWithExecutableCode",
+        "parameterTypes": []
+      },
+      {
+        "name": "testExecutableCode_TextPart",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFunctionCalls_EmptyCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFunctionCalls_EmptyParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFunctionCalls_MixedParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testFunctionCalls_PartWithFunctionCall",
+        "parameterTypes": []
+      },
+      {
+        "name": "testParts_EmptyCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testParts_MultipleCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testParts_MultipleParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testParts_SinglePart",
+        "parameterTypes": []
+      },
+      {
+        "name": "testParts_UnexpectedFinishReason",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_EmptyCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_EmptyParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_MixedParts",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_MultipleCandidates",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_MultiplePartsWithText",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_MultiplePartsWithThought",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_PartWithText",
+        "parameterTypes": []
+      },
+      {
+        "name": "testText_UnexpectedFinishReason",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.GenerateContentResponseTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerateContentResponseUsageMetadata"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "candidatesTokenCount",
+        "parameterTypes": [
+          "java.lang.Integer"
+        ]
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "promptTokenCount",
+        "parameterTypes": [
+          "java.lang.Integer"
+        ]
+      },
+      {
+        "name": "totalTokenCount",
+        "parameterTypes": [
+          "java.lang.Integer"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.GenerateContentResponseUsageMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerationConfigRoutingConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigAutoRoutingMode$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GenerationConfigRoutingConfigManualRoutingMode$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GoogleMaps$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GoogleSearch"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.GoogleSearch$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GoogleSearchRetrieval$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GoogleTypeDate$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GroundingChunk$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GroundingChunkRetrievedContext$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GroundingChunkWeb$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GroundingMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.GroundingSupport$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.HarmBlockMethod"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.HarmBlockThreshold"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.HarmCategory"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.HarmProbability"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.HarmSeverity"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.HttpOptions$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Interval$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Language"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LatLng$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LiveClientMessage"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LiveConnectConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LiveSendRealtimeInputParameters"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LogprobsResult$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LogprobsResultCandidate$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.LogprobsResultTopCandidates$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.MediaModality"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.MediaResolution"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ModalityTokenCount$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ModelRoutingPreference"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ModelSelectionConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.MultiSpeakerVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "speakerVoiceConfigs",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.MultiSpeakerVoiceConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Outcome"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Part"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "functionCall",
+        "parameterTypes": [
+          "com.google.genai.types.FunctionCall"
+        ]
+      },
+      {
+        "name": "functionResponse",
+        "parameterTypes": [
+          "com.google.genai.types.FunctionResponse"
+        ]
+      },
+      {
+        "name": "text",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Part$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPartFromBytes",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPartFromFunctionCall",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPartFromFunctionResponse",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPartFromText",
+        "parameterTypes": []
+      },
+      {
+        "name": "testPartFromUri",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.PartTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.PrebuiltVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "voiceName",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.PrebuiltVoiceConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagChunk$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagChunkPageSpan$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfigFilter$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfigHybridSearch$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfigRanking$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfigRankingLlmRanker$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RagRetrievalConfigRankingRankService$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Retrieval$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RetrievalConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.RetrievalMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "category",
+        "parameterTypes": [
+          "com.google.genai.types.HarmCategory"
+        ]
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.SafetyRating$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.SafetySetting$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Schema"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "items",
+        "parameterTypes": [
+          "com.google.genai.types.Schema"
+        ]
+      },
+      {
+        "name": "properties",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "required",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "title",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "type",
+        "parameterTypes": [
+          "com.google.genai.types.Type"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Schema$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.SearchEntryPoint$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Segment$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.SpeakerVoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "speaker",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "voiceConfig",
+        "parameterTypes": [
+          "com.google.genai.types.VoiceConfig"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.SpeakerVoiceConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.SpeechConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "multiSpeakerVoiceConfig",
+        "parameterTypes": [
+          "com.google.genai.types.MultiSpeakerVoiceConfig"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.SpeechConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ThinkingConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.Tool"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "functionDeclarations",
+        "parameterTypes": [
+          "java.util.List"
+        ]
+      },
+      {
+        "name": "googleSearch",
+        "parameterTypes": [
+          "com.google.genai.types.GoogleSearch"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.Tool$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ToolCodeExecution$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.ToolConfig$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.TrafficType"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "toString",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.Type"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.UrlContext$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.UrlContextMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.UrlMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.UrlRetrievalStatus"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VertexAISearch$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VertexAISearchDataStoreSpec$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VertexRagStore$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VertexRagStoreRagResource$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VideoMetadata"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "endOffset",
+        "parameterTypes": [
+          "java.time.Duration"
+        ]
+      },
+      {
+        "name": "startOffset",
+        "parameterTypes": [
+          "java.time.Duration"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.VideoMetadata$Builder"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSerializationDeserialization_nullDurations",
+        "parameterTypes": []
+      },
+      {
+        "name": "testSerializationDeserialization_withDurations",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.google.genai.types.VideoMetadataTest"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "com.google.genai.types.VoiceConfig"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "create",
+        "parameterTypes": []
+      },
+      {
+        "name": "prebuiltVoiceConfig",
+        "parameterTypes": [
+          "com.google.genai.types.PrebuiltVoiceConfig"
+        ]
+      }
+    ],
+    "name": "com.google.genai.types.VoiceConfig$Builder"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.AESCipher$General"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.ARCFOURCipher"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.DESCipher"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.DESedeCipher"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.crypto.provider.GaloisCounterMode$AESGCM"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl"
+  },
+  {
+    "name": "java.io.Closeable"
+  },
+  {
+    "name": "java.io.Serializable"
+  },
+  {
+    "name": "java.lang.AutoCloseable"
+  },
+  {
+    "name": "java.lang.Boolean"
+  },
+  {
+    "name": "java.lang.Byte"
+  },
+  {
+    "methods": [
+      {
+        "name": "getModule",
+        "parameterTypes": []
+      },
+      {
+        "name": "getNestHost",
+        "parameterTypes": []
+      },
+      {
+        "name": "isSealed",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.Class"
+  },
+  {
+    "name": "java.lang.ClassLoader"
+  },
+  {
+    "name": "java.lang.Cloneable"
+  },
+  {
+    "name": "java.lang.Comparable"
+  },
+  {
+    "methods": [
+      {
+        "name": "forRemoval",
+        "parameterTypes": []
+      },
+      {
+        "name": "since",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.Deprecated"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.lang.Double"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.lang.Float"
+  },
+  {
+    "name": "java.lang.Integer"
+  },
+  {
+    "name": "java.lang.Iterable"
+  },
+  {
+    "name": "java.lang.Long"
+  },
+  {
+    "methods": [
+      {
+        "name": "canRead",
+        "parameterTypes": [
+          "java.lang.Module"
+        ]
+      },
+      {
+        "name": "getLayer",
+        "parameterTypes": []
+      },
+      {
+        "name": "getName",
+        "parameterTypes": []
+      },
+      {
+        "name": "isOpen",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.Module"
+        ]
+      }
+    ],
+    "name": "java.lang.Module"
+  },
+  {
+    "methods": [
+      {
+        "name": "configuration",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.ModuleLayer"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.lang.Number"
+  },
+  {
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.Object"
+  },
+  {
+    "methods": [
+      {
+        "name": "version",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.Runtime"
+  },
+  {
+    "methods": [
+      {
+        "name": "major",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.Runtime$Version"
+  },
+  {
+    "name": "java.lang.SecurityManager"
+  },
+  {
+    "name": "java.lang.Short"
+  },
+  {
+    "name": "java.lang.String"
+  },
+  {
+    "name": "java.lang.System"
+  },
+  {
+    "name": "java.lang.constant.Constable"
+  },
+  {
+    "name": "java.lang.constant.ConstantDesc"
+  },
+  {
+    "methods": [
+      {
+        "name": "lookup",
+        "parameterTypes": []
+      },
+      {
+        "name": "privateLookupIn",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.invoke.MethodHandles$Lookup"
+        ]
+      }
+    ],
+    "name": "java.lang.invoke.MethodHandles"
+  },
+  {
+    "methods": [
+      {
+        "name": "defineClass",
+        "parameterTypes": [
+          "byte[]"
+        ]
+      },
+      {
+        "name": "lookupClass",
+        "parameterTypes": []
+      },
+      {
+        "name": "lookupModes",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.invoke.MethodHandles$Lookup"
+  },
+  {
+    "methods": [
+      {
+        "name": "getRuntimeMXBean",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.management.ManagementFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "getUptime",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.management.RuntimeMXBean"
+  },
+  {
+    "methods": [
+      {
+        "name": "findModule",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "java.lang.module.Configuration"
+  },
+  {
+    "methods": [
+      {
+        "name": "location",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.module.ModuleReference"
+  },
+  {
+    "methods": [
+      {
+        "name": "reference",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.module.ResolvedModule"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedGenericComponentType",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.AnnotatedArrayType"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedActualTypeArguments",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.AnnotatedParameterizedType"
+  },
+  {
+    "methods": [
+      {
+        "name": "getType",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.AnnotatedType"
+  },
+  {
+    "name": "java.lang.reflect.AnnotatedTypeVariable"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedUpperBounds",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.AnnotatedWildcardType"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedExceptionTypes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAnnotatedParameterTypes",
+        "parameterTypes": []
+      },
+      {
+        "name": "getAnnotatedReceiverType",
+        "parameterTypes": []
+      },
+      {
+        "name": "getParameterCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "getParameters",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.Executable"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedReturnType",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.Method"
+  },
+  {
+    "methods": [
+      {
+        "name": "getModifiers",
+        "parameterTypes": []
+      },
+      {
+        "name": "getName",
+        "parameterTypes": []
+      },
+      {
+        "name": "isNamePresent",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.Parameter"
+  },
+  {
+    "methods": [
+      {
+        "name": "getAnnotatedBounds",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.lang.reflect.TypeVariable"
+  },
+  {
+    "name": "java.security.AccessController"
+  },
+  {
+    "name": "java.security.AlgorithmParametersSpi"
+  },
+  {
+    "name": "java.security.KeyStoreSpi"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.util.AbstractCollection"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.util.AbstractMap"
+  },
+  {
+    "name": "java.util.Collection"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.util.HashMap"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "java.util.HashSet"
+  },
+  {
+    "name": "java.util.Iterator"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.util.LinkedHashMap"
+  },
+  {
+    "name": "java.util.List"
+  },
+  {
+    "name": "java.util.Map"
+  },
+  {
+    "name": "java.util.RandomAccess"
+  },
+  {
+    "name": "java.util.SequencedMap"
+  },
+  {
+    "allDeclaredFields": true,
+    "name": "java.util.UUID"
+  },
+  {
+    "name": "javax.annotation.Nullable"
+  },
+  {
+    "name": "kotlin.jvm.JvmInline"
+  },
+  {
+    "name": "net.bytebuddy.description.method.MethodDescription$InDefinedShape$AbstractBase$Executable"
+  },
+  {
+    "name": "net.bytebuddy.description.method.ParameterDescription$ForLoadedParameter$Parameter"
+  },
+  {
+    "name": "net.bytebuddy.description.method.ParameterList$ForLoadedExecutable$Executable"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDefinition$Sort$AnnotatedType"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$ForLoadedType$Dispatcher"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedExecutableExceptionType$Dispatcher"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedExecutableParameterType$Dispatcher"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$Delegator$ForLoadedMethodReturnType$Dispatcher"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForComponentType$AnnotatedParameterizedType"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeArgument$AnnotatedParameterizedType"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeVariableBoundType$AnnotatedTypeVariable"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForTypeVariableBoundType$OfFormalTypeVariable$FormalTypeVariable"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForWildcardLowerBoundType$AnnotatedWildcardType"
+  },
+  {
+    "name": "net.bytebuddy.description.type.TypeDescription$Generic$AnnotationReader$ForWildcardUpperBoundType$AnnotatedWildcardType"
+  },
+  {
+    "name": "net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup$MethodHandles"
+  },
+  {
+    "name": "net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup$MethodHandles$Lookup"
+  },
+  {
+    "name": "net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection$System"
+  },
+  {
+    "methods": [
+      {
+        "name": "includeSelf",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.AllArguments"
+  },
+  {
+    "methods": [
+      {
+        "name": "bindingMechanic",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.Argument"
+  },
+  {
+    "name": "net.bytebuddy.implementation.bind.annotation.Default"
+  },
+  {
+    "name": "net.bytebuddy.implementation.bind.annotation.DefaultCall"
+  },
+  {
+    "name": "net.bytebuddy.implementation.bind.annotation.DefaultMethod"
+  },
+  {
+    "methods": [
+      {
+        "name": "declaringType",
+        "parameterTypes": []
+      },
+      {
+        "name": "value",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.FieldValue"
+  },
+  {
+    "methods": [
+      {
+        "name": "cache",
+        "parameterTypes": []
+      },
+      {
+        "name": "privileged",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.Origin"
+  },
+  {
+    "name": "net.bytebuddy.implementation.bind.annotation.StubValue"
+  },
+  {
+    "name": "net.bytebuddy.implementation.bind.annotation.Super"
+  },
+  {
+    "methods": [
+      {
+        "name": "fallbackToDefault",
+        "parameterTypes": []
+      },
+      {
+        "name": "nullIfImpossible",
+        "parameterTypes": []
+      },
+      {
+        "name": "serializableProxy",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.SuperCall"
+  },
+  {
+    "methods": [
+      {
+        "name": "optional",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.implementation.bind.annotation.This"
+  },
+  {
+    "name": "net.bytebuddy.utility.Invoker"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "net.bytebuddy.utility.Invoker$Dispatcher"
+  },
+  {
+    "name": "net.bytebuddy.utility.JavaModule$Module"
+  },
+  {
+    "name": "net.bytebuddy.utility.JavaModule$Resolver"
+  },
+  {
+    "name": "org.apache.commons.logging.LogFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ],
+    "name": "org.apache.commons.logging.impl.Jdk14Logger"
+  },
+  {
+    "name": "org.apache.commons.logging.impl.Log4JLogger"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.commons.logging.impl.LogFactoryImpl"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.apache.commons.logging.impl.WeakHashtable"
+  },
+  {
+    "name": "org.apache.http.HttpEntity"
+  },
+  {
+    "name": "org.apache.http.HttpMessage"
+  },
+  {
+    "name": "org.apache.http.HttpResponse"
+  },
+  {
+    "name": "org.apache.http.client.HttpClient"
+  },
+  {
+    "name": "org.apache.http.client.methods.CloseableHttpResponse"
+  },
+  {
+    "name": "org.apache.http.impl.client.CloseableHttpClient"
+  },
+  {
+    "fields": [
+      {
+        "name": "connManager"
+      },
+      {
+        "name": "defaultConfig"
+      }
+    ],
+    "name": "org.apache.http.impl.client.InternalHttpClient"
+  },
+  {
+    "name": "org.apache.maven.surefire.booter.spi.LegacyMasterProcessChannelProcessorFactory"
+  },
+  {
+    "name": "org.apache.maven.surefire.booter.spi.SurefireMasterProcessChannelProcessorFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "org.apache.maven.surefire.api.provider.ProviderParameters"
+        ]
+      }
+    ],
+    "name": "org.apache.maven.surefire.junitplatform.JUnitPlatformProvider"
+  },
+  {
+    "name": "org.apiguardian.api.API"
+  },
+  {
+    "name": "org.eclipse.jetty.http.Http1FieldPreEncoder"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.eclipse.jetty.http.pathmap.PathSpecSet"
+  },
+  {
+    "name": "org.eclipse.jetty.http2.hpack.HpackFieldPreEncoder"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      },
+      {
+        "name": "addIncludedMethods",
+        "parameterTypes": [
+          "java.lang.String[]"
+        ]
+      }
+    ],
+    "name": "org.eclipse.jetty.server.handler.gzip.GzipHandler"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.eclipse.jetty.servlets.CrossOriginFilter"
+  },
+  {
+    "name": "org.eclipse.jetty.servlets.gzip.GzipHandler"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.eclipse.jetty.util.ModuleLocation"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.eclipse.jetty.util.RegexSet"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.eclipse.jetty.util.log.Slf4jLog"
+  },
+  {
+    "name": "org.jspecify.annotations.Nullable"
+  },
+  {
+    "name": "org.junit.internal.AssumptionViolatedException"
+  },
+  {
+    "name": "org.junit.jupiter.api.Disabled"
+  },
+  {
+    "name": "org.junit.jupiter.api.DisplayName"
+  },
+  {
+    "name": "org.junit.jupiter.api.Test"
+  },
+  {
+    "name": "org.junit.jupiter.api.TestFactory"
+  },
+  {
+    "name": "org.junit.jupiter.api.TestTemplate"
+  },
+  {
+    "name": "org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.junit.jupiter.api.condition.EnabledIfEnvironmentVariableCondition"
+  },
+  {
+    "name": "org.junit.jupiter.api.extension.ExtendWith"
+  },
+  {
+    "name": "org.junit.jupiter.engine.JupiterTestEngine"
+  },
+  {
+    "name": "org.junit.jupiter.params.ParameterizedTest"
+  },
+  {
+    "name": "org.junit.jupiter.params.provider.ArgumentsSource"
+  },
+  {
+    "name": "org.junit.jupiter.params.provider.CsvSource"
+  },
+  {
+    "name": "org.junit.jupiter.params.provider.ValueSource"
+  },
+  {
+    "name": "org.junit.platform.commons.annotation.Testable"
+  },
+  {
+    "methods": [
+      {
+        "name": "getLauncher",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.junit.platform.launcher.LauncherSession"
+  },
+  {
+    "methods": [
+      {
+        "name": "openSession",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.junit.platform.launcher.core.LauncherFactory"
+  },
+  {
+    "name": "org.junit.platform.launcher.listeners.UniqueIdTrackingListener"
+  },
+  {
+    "name": "org.mockito.Mock"
+  },
+  {
+    "name": "org.mockito.configuration.MockitoConfiguration"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.configuration.InjectingAnnotationEngine"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.configuration.plugins.DefaultPluginSwitch"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.creation.bytebuddy.ByteBuddyMockMaker"
+  },
+  {
+    "name": "org.mockito.internal.creation.bytebuddy.MockAccess"
+  },
+  {
+    "name": "org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$DispatcherDefaultingToRealMethod"
+  },
+  {
+    "name": "org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$ForEquals"
+  },
+  {
+    "name": "org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$ForHashCode"
+  },
+  {
+    "name": "org.mockito.internal.creation.bytebuddy.MockMethodInterceptor$ForWriteReplace"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.creation.instance.DefaultInstantiatorProvider"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.exceptions.stacktrace.DefaultStackTraceCleanerProvider"
+  },
+  {
+    "name": "org.mockito.internal.matchers.Any"
+  },
+  {
+    "name": "org.mockito.internal.matchers.CapturingMatcher"
+  },
+  {
+    "name": "org.mockito.internal.matchers.InstanceOf"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.util.ConsoleMockitoLogger"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "org.mockito.internal.util.reflection.ReflectionMemberAccessor"
+  },
+  {
+    "name": "sun.misc.SharedSecrets"
+  },
+  {
+    "methods": [
+      {
+        "name": "getReflectionFactory",
+        "parameterTypes": []
+      },
+      {
+        "name": "newConstructorForSerialization",
+        "parameterTypes": [
+          "java.lang.Class",
+          "java.lang.reflect.Constructor"
+        ]
+      }
+    ],
+    "name": "sun.reflect.ReflectionFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.pkcs12.PKCS12KeyStore"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.pkcs12.PKCS12KeyStore$DualFormatPKCS12"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.security.SecureRandomParameters"
+        ]
+      }
+    ],
+    "name": "sun.security.provider.NativePRNG"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.provider.SHA"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.provider.X509Factory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.rsa.RSAKeyFactory$Legacy"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.ssl.SSLContextImpl$TLSContext"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ],
+    "name": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.AuthorityInfoAccessExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.AuthorityKeyIdentifierExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.BasicConstraintsExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.CRLDistributionPointsExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.CertificatePoliciesExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.ExtendedKeyUsageExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.IssuerAlternativeNameExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.KeyUsageExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.NetscapeCertTypeExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.PrivateKeyUsageExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.SubjectAlternativeNameExtension"
+  },
+  {
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.Boolean",
+          "java.lang.Object"
+        ]
+      }
+    ],
+    "name": "sun.security.x509.SubjectKeyIdentifierExtension"
   }
 ]

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/resource-config.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "com/google/genai/.*"
+      },
+      {
+        "pattern": "META-INF/services/.*"
+      },
+      {
+        "pattern": ".*\\.properties$"
+      },
+      {
+        "pattern": ".*\\.json$"
+      }
+    ]
+  }
+}

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/resource-config.json
@@ -2,17 +2,165 @@
   "resources": {
     "includes": [
       {
-        "pattern": "com/google/genai/.*"
+        "pattern": "META-INF/services/com.google.auth.http.HttpTransportFactory"
       },
       {
-        "pattern": "META-INF/services/.*"
+        "pattern": "META-INF/services/java.lang.System$LoggerFinder"
       },
       {
-        "pattern": ".*\\.properties$"
+        "pattern": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
       },
       {
-        "pattern": ".*\\.json$"
+        "pattern": "META-INF/services/java.nio.channels.spi.SelectorProvider"
+      },
+      {
+        "pattern": "META-INF/services/java.time.zone.ZoneRulesProvider"
+      },
+      {
+        "pattern": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+      },
+      {
+        "pattern": "META-INF/services/javax.xml.transform.TransformerFactory"
+      },
+      {
+        "pattern": "META-INF/services/javax.xml.xpath.XPathFactory"
+      },
+      {
+        "pattern": "META-INF/services/org.apache.commons.logging.LogFactory"
+      },
+      {
+        "pattern": "META-INF/services/org.apache.maven.surefire.spi.MasterProcessChannelProcessorFactory"
+      },
+      {
+        "pattern": "META-INF/services/org.eclipse.jetty.http.HttpFieldPreEncoder"
+      },
+      {
+        "pattern": "META-INF/services/org.junit.platform.engine.TestEngine"
+      },
+      {
+        "pattern": "META-INF/services/org.junit.platform.launcher.LauncherDiscoveryListener"
+      },
+      {
+        "pattern": "META-INF/services/org.junit.platform.launcher.LauncherSessionListener"
+      },
+      {
+        "pattern": "META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter"
+      },
+      {
+        "pattern": "META-INF/services/org.junit.platform.launcher.TestExecutionListener"
+      },
+      {
+        "pattern": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+      },
+      {
+        "pattern": "assets"
+      },
+      {
+        "pattern": "assets/swagger-ui/index.html"
+      },
+      {
+        "pattern": "commons-logging.properties"
+      },
+      {
+        "pattern": "javax/servlet/LocalStrings.properties"
+      },
+      {
+        "pattern": "javax/servlet/LocalStrings_en.properties"
+      },
+      {
+        "pattern": "javax/servlet/LocalStrings_en_CA.properties"
+      },
+      {
+        "pattern": "javax/servlet/http/LocalStrings.properties"
+      },
+      {
+        "pattern": "javax/servlet/http/LocalStrings_en.properties"
+      },
+      {
+        "pattern": "javax/servlet/http/LocalStrings_en_CA.properties"
+      },
+      {
+        "pattern": "jetty-logging-mac-os-x.properties"
+      },
+      {
+        "pattern": "jetty-logging.properties"
+      },
+      {
+        "pattern": "junit-platform.properties"
+      },
+      {
+        "pattern": "keystore"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.AnnotationEngine"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.InstantiatorProvider"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.InstantiatorProvider2"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.MemberAccessor"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.MockMaker"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.MockResolver"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.MockitoLogger"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.PluginSwitch"
+      },
+      {
+        "pattern": "mockito-extensions/org.mockito.plugins.StackTraceCleanerProvider"
+      },
+      {
+        "pattern": "mozilla/public-suffix-list.txt"
+      },
+      {
+        "pattern": "org/apache/hc/client5/version.properties"
+      },
+      {
+        "pattern": "org/apache/http/client/version.properties"
+      },
+      {
+        "pattern": "org/eclipse/jetty/http/encoding.properties"
+      },
+      {
+        "pattern": "org/eclipse/jetty/http/mime.properties"
+      },
+      {
+        "pattern": "org/eclipse/jetty/version/build.properties"
+      },
+      {
+        "pattern": "org/jacoco/agent/rt/internal_aeaf9ab/core/jacoco.properties"
+      },
+      {
+        "pattern": "org/jacoco/agent/rt/internal_aeaf9ab/core/jacoco_en.properties"
+      },
+      {
+        "pattern": "org/jacoco/agent/rt/internal_aeaf9ab/core/jacoco_en_CA.properties"
+      },
+      {
+        "pattern": "org/slf4j/impl/StaticLoggerBinder.class"
+      },
+      {
+        "pattern": "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+      },
+      {
+        "pattern": "sun/util/logging/resources/logging_en.properties"
+      },
+      {
+        "pattern": "sun/util/logging/resources/logging_en_CA.properties"
+      },
+      {
+        "pattern": "jdk/xml/internal/jdkcatalog/JDKCatalog.xml"
       }
-    ]
+    ],
+    "excludes": []
   }
 }

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/serialization-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/serialization-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "com.google.auth.oauth2.GoogleCredentials$MockitoMock$413565573",
+    "customTargetConstructorClass": "java.lang.Object"
+  },
+  {
+    "name": "org.junit.platform.launcher.TestIdentifier$SerializedForm"
+  }
+]

--- a/src/test/java/com/google/genai/CommonTest.java
+++ b/src/test/java/com/google/genai/CommonTest.java
@@ -151,6 +151,15 @@ public class CommonTest {
   }
 
   @Test
+  public void testFormatMap_nonValueNode() {
+    ObjectNode data = JsonSerializable.objectMapper.createObjectNode();
+    data.putObject("person").put("name", "John");
+    String template = "This is a {person}.";
+    String expected = "This is a {person}.";
+    assertEquals(expected, Common.formatMap(template, data));
+  }
+
+  @Test
   public void testIsZero_null() {
     assertTrue(Common.isZero(null));
   }


### PR DESCRIPTION
[DO NOT MERGE]
Attention: @jaycee-li.

This PR adds native image support to the java-genai library.
The build supports native-tests to validate changes.

TODO: add here a link to an app building a native image using the java-genai library