### PR TITLE
fix: ChatBase constructor ignores history parameters

### DIFF
--- a/src/main/java/com/google/genai/ChatBase.java
+++ b/src/main/java/com/google/genai/ChatBase.java
@@ -37,8 +37,8 @@ class ChatBase {
   private static final Logger logger = Logger.getLogger(ChatBase.class.getName());
 
   ChatBase(List<Content> comprehensiveHistory, List<Content> curatedHistory) {
-    this.comprehensiveHistory = new ArrayList<>();
-    this.curatedHistory = new ArrayList<>();
+    this.comprehensiveHistory = comprehensiveHistory;
+    this.curatedHistory = curatedHistory;
   }
 
   /**


### PR DESCRIPTION
The `ChatBase` constructor accepts `comprehensiveHistory` and `curatedHistory` parameters but never uses them—both fields are always initialized as empty `ArrayList` instances regardless of what's passed in.

## The Bug
```java
// Before (broken)
ChatBase(List comprehensiveHistory, List curatedHistory) {
  this.comprehensiveHistory = new ArrayList<>();
  this.curatedHistory = new ArrayList<>();
}
```

## The Fix
```java
// After (fixed)
ChatBase(List comprehensiveHistory, List curatedHistory) {
  this.comprehensiveHistory = comprehensiveHistory;
  this.curatedHistory = curatedHistory;
}
```

## Impact

This bug would prevent any functionality that relies on initializing a chat session with existing conversation history from working correctly.