### PR TITLE
fix: 'No SLF4J providers were found' on examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -69,5 +69,15 @@
       <artifactId>google-genai</artifactId>
       <version>${google-genai.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <version>2.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This fixes the _"No SLF4J providers were found. Defaulting to no-operation (NOP) logger implementation. See https://www.slf4j.org/codes.html#noProviders for further details."_ problem seen when running examples:

```
$ mvn compile exec:java -Dexec.mainClass="com.google.genai.examples.LiveAudioConversationAsync"

[INFO] --- exec:3.5.0:java (default-cli) @ google-genai-examples ---
Using Gemini Developer API
Microphone line opened.
Speaker line opened.
Connecting to Gemini Live API...
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
Connected.
Microphone and speakers started. Speak now (Press Ctrl+C to exit)...
Receive stream started.
```

While java-genai uses JUL as its logging framework, one of its dependencies appears to use SLF4J, so doing is a good idea.

Of course, this only belongs into the `example/pom.xml` and NOT the root `pom.xml` obviously.