### PR TITLE
fix: strip `id` field from FunctionCall/FunctionResponse before sending to Gemini API

### DIFF
--- a/src/main/java/com/google/genai/Batches.java
+++ b/src/main/java/com/google/genai/Batches.java
@@ -1095,11 +1095,6 @@ public final class Batches {
   @ExcludeFromGeneratedCoverageReport
   ObjectNode functionCallToMldev(JsonNode fromObject, ObjectNode parentObject) {
     ObjectNode toObject = JsonSerializable.objectMapper().createObjectNode();
-    if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
-      Common.setValueByPath(
-          toObject, new String[] {"id"}, Common.getValueByPath(fromObject, new String[] {"id"}));
-    }
-
     if (Common.getValueByPath(fromObject, new String[] {"args"}) != null) {
       Common.setValueByPath(
           toObject,
@@ -1846,10 +1841,13 @@ public final class Batches {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {

--- a/src/main/java/com/google/genai/Caches.java
+++ b/src/main/java/com/google/genai/Caches.java
@@ -457,11 +457,6 @@ public final class Caches {
   @ExcludeFromGeneratedCoverageReport
   ObjectNode functionCallToMldev(JsonNode fromObject, ObjectNode parentObject) {
     ObjectNode toObject = JsonSerializable.objectMapper().createObjectNode();
-    if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
-      Common.setValueByPath(
-          toObject, new String[] {"id"}, Common.getValueByPath(fromObject, new String[] {"id"}));
-    }
-
     if (Common.getValueByPath(fromObject, new String[] {"args"}) != null) {
       Common.setValueByPath(
           toObject,
@@ -818,10 +813,13 @@ public final class Caches {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {
@@ -925,10 +923,13 @@ public final class Caches {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {

--- a/src/main/java/com/google/genai/LiveConverters.java
+++ b/src/main/java/com/google/genai/LiveConverters.java
@@ -180,11 +180,6 @@ final class LiveConverters {
   @ExcludeFromGeneratedCoverageReport
   ObjectNode functionCallToMldev(JsonNode fromObject, ObjectNode parentObject) {
     ObjectNode toObject = JsonSerializable.objectMapper().createObjectNode();
-    if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
-      Common.setValueByPath(
-          toObject, new String[] {"id"}, Common.getValueByPath(fromObject, new String[] {"id"}));
-    }
-
     if (Common.getValueByPath(fromObject, new String[] {"args"}) != null) {
       Common.setValueByPath(
           toObject,
@@ -1693,10 +1688,13 @@ final class LiveConverters {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {
@@ -1800,10 +1798,13 @@ final class LiveConverters {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {

--- a/src/main/java/com/google/genai/Models.java
+++ b/src/main/java/com/google/genai/Models.java
@@ -1316,11 +1316,6 @@ public final class Models {
   ObjectNode functionCallToMldev(
       JsonNode fromObject, ObjectNode parentObject, JsonNode rootObject) {
     ObjectNode toObject = JsonSerializable.objectMapper().createObjectNode();
-    if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
-      Common.setValueByPath(
-          toObject, new String[] {"id"}, Common.getValueByPath(fromObject, new String[] {"id"}));
-    }
-
     if (Common.getValueByPath(fromObject, new String[] {"args"}) != null) {
       Common.setValueByPath(
           toObject,
@@ -4156,10 +4151,13 @@ public final class Models {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {

--- a/src/main/java/com/google/genai/TokensConverters.java
+++ b/src/main/java/com/google/genai/TokensConverters.java
@@ -232,11 +232,6 @@ final class TokensConverters {
   @ExcludeFromGeneratedCoverageReport
   ObjectNode functionCallToMldev(JsonNode fromObject, ObjectNode parentObject) {
     ObjectNode toObject = JsonSerializable.objectMapper().createObjectNode();
-    if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
-      Common.setValueByPath(
-          toObject, new String[] {"id"}, Common.getValueByPath(fromObject, new String[] {"id"}));
-    }
-
     if (Common.getValueByPath(fromObject, new String[] {"args"}) != null) {
       Common.setValueByPath(
           toObject,
@@ -562,10 +557,13 @@ final class TokensConverters {
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"functionResponse"}) != null) {
-      Common.setValueByPath(
-          toObject,
-          new String[] {"functionResponse"},
-          Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      JsonNode functionResponseNode =
+          JsonSerializable.toJsonNode(
+              Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
+      if (functionResponseNode instanceof ObjectNode) {
+        ((ObjectNode) functionResponseNode).remove("id");
+      }
+      Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
     }
 
     if (Common.getValueByPath(fromObject, new String[] {"inlineData"}) != null) {

--- a/src/test/java/com/google/genai/FunctionCallIdStrippingTest.java
+++ b/src/test/java/com/google/genai/FunctionCallIdStrippingTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.genai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionResponse;
+import com.google.genai.types.Part;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the {@code id} field is stripped from {@code FunctionCall} and {@code
+ * FunctionResponse} objects before they are sent to the Gemini API (Mldev format), while remaining
+ * available for deserialization and client-side use.
+ */
+public class FunctionCallIdStrippingTest {
+
+  private ApiClient apiClient;
+  private Models models;
+  private Batches batches;
+  private LiveConverters liveConverters;
+  private TokensConverters tokensConverters;
+  private Caches caches;
+
+  @BeforeEach
+  public void setUp() {
+    apiClient = mock(ApiClient.class);
+    models = new Models(apiClient);
+    batches = new Batches(apiClient);
+    liveConverters = new LiveConverters(apiClient);
+    tokensConverters = new TokensConverters(apiClient);
+    caches = new Caches(apiClient);
+  }
+
+  // ---------------------------------------------------------------------------
+  // functionCallToMldev — id stripping
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFunctionCallToMldev_withId_idIsStripped_Models() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("call_123")
+            .name("getWeather")
+            .args(ImmutableMap.<String, Object>of("city", "Seattle"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.functionCallToMldev(fromObject, parentObject, rootObject);
+
+    assertNull(result.get("id"), "id should be stripped from functionCall");
+    assertEquals("getWeather", result.get("name").asText());
+    assertNotNull(result.get("args"));
+  }
+
+  @Test
+  public void testFunctionCallToMldev_withId_idIsStripped_Batches() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("call_456")
+            .name("search")
+            .args(ImmutableMap.<String, Object>of("q", "test"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = batches.functionCallToMldev(fromObject, parentObject);
+
+    assertNull(result.get("id"), "id should be stripped from functionCall");
+    assertEquals("search", result.get("name").asText());
+  }
+
+  @Test
+  public void testFunctionCallToMldev_withId_idIsStripped_LiveConverters() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("call_live")
+            .name("stream")
+            .args(ImmutableMap.<String, Object>of("ch", "main"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = liveConverters.functionCallToMldev(fromObject, parentObject);
+
+    assertNull(result.get("id"), "id should be stripped from functionCall");
+    assertEquals("stream", result.get("name").asText());
+  }
+
+  @Test
+  public void testFunctionCallToMldev_withId_idIsStripped_TokensConverters() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("call_tok")
+            .name("count")
+            .args(ImmutableMap.<String, Object>of("t", "hi"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = tokensConverters.functionCallToMldev(fromObject, parentObject);
+
+    assertNull(result.get("id"), "id should be stripped from functionCall");
+    assertEquals("count", result.get("name").asText());
+  }
+
+  @Test
+  public void testFunctionCallToMldev_withId_idIsStripped_Caches() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("call_cache")
+            .name("lookup")
+            .args(ImmutableMap.<String, Object>of("key", "abc"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = caches.functionCallToMldev(fromObject, parentObject);
+
+    assertNull(result.get("id"), "id should be stripped from functionCall");
+    assertEquals("lookup", result.get("name").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // functionCallToMldev — regression: no id present
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFunctionCallToMldev_withoutId_worksNormally() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .name("getWeather")
+            .args(ImmutableMap.<String, Object>of("city", "Portland"))
+            .build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.functionCallToMldev(fromObject, parentObject, rootObject);
+
+    assertNull(result.get("id"));
+    assertEquals("getWeather", result.get("name").asText());
+    assertNotNull(result.get("args"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // functionCallToMldev — name and args preserved
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFunctionCallToMldev_nameOnly() {
+    FunctionCall fc = FunctionCall.builder().name("noArgs").build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(fc);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.functionCallToMldev(fromObject, parentObject, rootObject);
+
+    assertNull(result.get("id"));
+    assertEquals("noArgs", result.get("name").asText());
+    assertNull(result.get("args"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // partToMldev — functionResponse id stripping
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testPartToMldev_functionResponseWithId_idIsStripped_Models() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("call_123")
+            .name("getWeather")
+            .response(ImmutableMap.<String, Object>of("output", "sunny"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.partToMldev(fromObject, parentObject, rootObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode, "functionResponse should exist in output");
+    assertNull(frNode.get("id"), "id should be stripped from functionResponse");
+    assertEquals("getWeather", frNode.get("name").asText());
+  }
+
+  @Test
+  public void testPartToMldev_functionResponseWithId_idIsStripped_Batches() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("call_456")
+            .name("search")
+            .response(ImmutableMap.<String, Object>of("output", "results"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = batches.partToMldev(fromObject, parentObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode);
+    assertNull(frNode.get("id"), "id should be stripped from functionResponse");
+    assertEquals("search", frNode.get("name").asText());
+  }
+
+  @Test
+  public void testPartToMldev_functionResponseWithId_idIsStripped_LiveConverters() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("call_live")
+            .name("stream")
+            .response(ImmutableMap.<String, Object>of("output", "data"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = liveConverters.partToMldev(fromObject, parentObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode);
+    assertNull(frNode.get("id"), "id should be stripped from functionResponse");
+    assertEquals("stream", frNode.get("name").asText());
+  }
+
+  @Test
+  public void testPartToMldev_functionResponseWithId_idIsStripped_TokensConverters() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("call_tok")
+            .name("count")
+            .response(ImmutableMap.<String, Object>of("output", "42"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = tokensConverters.partToMldev(fromObject, parentObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode);
+    assertNull(frNode.get("id"), "id should be stripped from functionResponse");
+    assertEquals("count", frNode.get("name").asText());
+  }
+
+  @Test
+  public void testPartToMldev_functionResponseWithId_idIsStripped_Caches() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("call_cache")
+            .name("lookup")
+            .response(ImmutableMap.<String, Object>of("output", "hit"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = caches.partToMldev(fromObject, parentObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode);
+    assertNull(frNode.get("id"), "id should be stripped from functionResponse");
+    assertEquals("lookup", frNode.get("name").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // partToMldev — regression: functionResponse without id
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testPartToMldev_functionResponseWithoutId_worksNormally() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .name("getWeather")
+            .response(ImmutableMap.<String, Object>of("output", "rainy"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.partToMldev(fromObject, parentObject, rootObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNotNull(frNode);
+    assertNull(frNode.get("id"));
+    assertEquals("getWeather", frNode.get("name").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // partToMldev — all fields except id are preserved in functionResponse
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testPartToMldev_functionResponse_preservesAllFieldsExceptId() {
+    FunctionResponse fr =
+        FunctionResponse.builder()
+            .id("strip_me")
+            .name("importantFunc")
+            .response(ImmutableMap.<String, Object>of("result", "success", "data", "payload"))
+            .build();
+    Part part = Part.builder().functionResponse(fr).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.partToMldev(fromObject, parentObject, rootObject);
+
+    JsonNode frNode = result.get("functionResponse");
+    assertNull(frNode.get("id"), "id should be stripped");
+    assertEquals("importantFunc", frNode.get("name").asText());
+    assertEquals("success", frNode.get("response").get("result").asText());
+    assertEquals("payload", frNode.get("response").get("data").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // partToMldev — functionCall inside Part has id stripped
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testPartToMldev_functionCallWithId_idIsStripped() {
+    FunctionCall fc =
+        FunctionCall.builder()
+            .id("fc_e2e")
+            .name("lookupUser")
+            .args(ImmutableMap.<String, Object>of("userId", "u123"))
+            .build();
+    Part part = Part.builder().functionCall(fc).build();
+    JsonNode fromObject = JsonSerializable.toJsonNode(part);
+    ObjectNode parentObject = JsonSerializable.objectMapper().createObjectNode();
+    JsonNode rootObject = JsonSerializable.objectMapper().createObjectNode();
+
+    ObjectNode result = models.partToMldev(fromObject, parentObject, rootObject);
+
+    JsonNode fcNode = result.get("functionCall");
+    assertNotNull(fcNode, "functionCall should exist in output");
+    assertNull(fcNode.get("id"), "id should be stripped from functionCall");
+    assertEquals("lookupUser", fcNode.get("name").asText());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Deserialization: id field is still readable from API responses
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFunctionCall_idStillDeserializable() {
+    String json = "{\"id\":\"call_999\",\"name\":\"myFunc\",\"args\":{\"key\":\"value\"}}";
+    FunctionCall fc = JsonSerializable.fromJsonString(json, FunctionCall.class);
+
+    assertTrue(fc.id().isPresent());
+    assertEquals("call_999", fc.id().get());
+    assertEquals("myFunc", fc.name().get());
+  }
+
+  @Test
+  public void testFunctionResponse_idStillDeserializable() {
+    String json = "{\"id\":\"call_999\",\"name\":\"myFunc\",\"response\":{\"out\":\"done\"}}";
+    FunctionResponse fr = JsonSerializable.fromJsonString(json, FunctionResponse.class);
+
+    assertTrue(fr.id().isPresent());
+    assertEquals("call_999", fr.id().get());
+    assertEquals("myFunc", fr.name().get());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Client-side serialization: id still appears in toJson() output
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testFunctionCall_clientSideSerializationStillIncludesId() {
+    FunctionCall fc = FunctionCall.builder().id("serialize_me").name("testFunc").build();
+    String json = fc.toJson();
+
+    assertTrue(json.contains("\"id\":\"serialize_me\""),
+        "id should still appear in client-side toJson() output");
+  }
+
+  @Test
+  public void testFunctionResponse_clientSideSerializationStillIncludesId() {
+    FunctionResponse fr = FunctionResponse.builder().id("serialize_me").name("testFunc").build();
+    String json = fr.toJson();
+
+    assertTrue(json.contains("\"id\":\"serialize_me\""),
+        "id should still appear in client-side toJson() output");
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #694

The Gemini API rejects requests that include an `id` field inside `contents[].parts[].function_call` or `contents[].parts[].function_response`, returning:

```
400 Invalid JSON payload received. Unknown name "id" at 'contents[5].parts[0].function_call': Cannot find field.
400 Invalid JSON payload received. Unknown name "id" at 'contents[6].parts[0].function_response': Cannot find field.
```

This surfaces in multi-turn / multi-agent workflows (e.g. Google ADK) where the SDK serializes `FunctionCall` and `FunctionResponse` objects that carry an `id` field populated from a previous model response. The field is valid on the **inbound** (model → client) side but is not accepted on the **outbound** (client → API) side.

---

## Root Cause

The converter methods in the five converter files (`Models`, `Batches`, `Caches`, `LiveConverters`, `TokensConverters`) were copying every field from the type object into the outbound JSON, including `id`.

**Before** — `functionCallToMldev` in each converter copied `id` unconditionally:

```java
// copied into outbound JSON — causes 400
if (Common.getValueByPath(fromObject, new String[] {"id"}) != null) {
  Common.setValueByPath(
      toObject,
      new String[] {"id"},
      Common.getValueByPath(fromObject, new String[] {"id"}));
}
```

**Before** — `partToMldev` passed `functionResponse` through as-is (including `id`):

```java
Common.setValueByPath(
    toObject,
    new String[] {"functionResponse"},
    Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
```

---

## Fix

**After** — the `id` copy-block is removed from `functionCallToMldev` in all five files.

**After** — `partToMldev` converts `functionResponse` to a `JsonNode` and explicitly removes `id` before forwarding:

```java
JsonNode functionResponseNode =
    JsonSerializable.toJsonNode(
        Common.getValueByPath(fromObject, new String[] {"functionResponse"}));
if (functionResponseNode instanceof ObjectNode) {
  ((ObjectNode) functionResponseNode).remove("id");
}
Common.setValueByPath(toObject, new String[] {"functionResponse"}, functionResponseNode);
```

The `id` field is **intentionally kept** in `FunctionCall.java` and `FunctionResponse.java` so the SDK can still deserialize it from inbound model responses.

---

## Files Changed

| File | Change |
|---|---|
| `Models.java` | Remove `id` from `functionCallToMldev`; strip `id` in `partToMldev` |
| `Batches.java` | Same |
| `Caches.java` | Same (2 occurrences of `partToMldev`) |
| `LiveConverters.java` | Same (2 occurrences of `partToMldev`) |
| `TokensConverters.java` | Same |
| `FunctionCallIdStrippingTest.java` | New test: 20 tests covering all 5 converters |

---

## Testing

Added `FunctionCallIdStrippingTest.java` with 20 JUnit 5 tests:
- `id` is stripped from `FunctionCall` in all 5 converters
- `id` is stripped from `FunctionResponse` in all 5 converters
- Non-`id` fields (`name`, `args`, `response`) are preserved
- `FunctionCall`/`FunctionResponse` type objects still deserialize `id` from JSON (regression guard)
- Edge cases: no `id` present, name-only function call

All 20 tests pass.