### PR TITLE
fix: preserve displayName and other config in uploadToFileSearchStore

### DIFF
--- a/src/main/java/com/google/genai/AsyncFileSearchStores.java
+++ b/src/main/java/com/google/genai/AsyncFileSearchStores.java
@@ -189,9 +189,12 @@ public final class AsyncFileSearchStores {
     HttpOptions httpOptions =
         UploadClient.buildResumableUploadHttpOptions(
             userHttpOptions, mimeTypeToUse, fileName, size);
+    if (config == null) {
+      config = UploadToFileSearchStoreConfig.builder().build();
+    }
     return privateUploadToFileSearchStore(
             fileSearchStoreName,
-            UploadToFileSearchStoreConfig.builder()
+            config.toBuilder()
                 .httpOptions(httpOptions)
                 .shouldReturnHttpResponse(true)
                 .build())

--- a/src/main/java/com/google/genai/FileSearchStores.java
+++ b/src/main/java/com/google/genai/FileSearchStores.java
@@ -929,10 +929,13 @@ public final class FileSearchStores {
     HttpOptions httpOptions =
         UploadClient.buildResumableUploadHttpOptions(
             userHttpOptions, mimeTypeToUse, fileName, size);
+    if (config == null) {
+      config = UploadToFileSearchStoreConfig.builder().build();
+    }
     UploadToFileSearchStoreResumableResponse response =
         privateUploadToFileSearchStore(
             fileSearchStoreName,
-            UploadToFileSearchStoreConfig.builder()
+            config.toBuilder()
                 .httpOptions(httpOptions)
                 .shouldReturnHttpResponse(true)
                 .build());


### PR DESCRIPTION
## Fix

Fixes #821,

Use `config.toBuilder()` instead of a new builder
so all user-provided fields are preserved before overriding internal-only fields.

## Testing

```sh
Tests run: 457, Failures: 0, Errors: 0, Skipped: 75
```