### PR TITLE
feat: Add history config to live connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,35 @@ Client client = Client.builder()
 The Google Gen AI Java SDK allows you to access the service programmatically.
 The following code snippets are some basic usages of model inferencing.
 
+#### Seed Live API conversation history
+
+Gemini 3.1 Live sessions can accept conversation history through client content
+messages before realtime input begins. Enable initial history processing when
+connecting:
+
+```java
+import com.google.genai.Client;
+import com.google.genai.types.HistoryConfig;
+import com.google.genai.types.LiveConnectConfig;
+import com.google.genai.types.Modality;
+
+Client client = new Client();
+
+LiveConnectConfig config =
+    LiveConnectConfig.builder()
+        .responseModalities(Modality.Known.AUDIO)
+        .historyConfig(
+            HistoryConfig.builder()
+                .initialHistoryInClientContent(true))
+        .build();
+
+client.async.live.connect("gemini-3.1-flash-live-preview", config);
+```
+
+After the session connects, use `sendClientContent` to send the initial history
+and finish it with `turnComplete(true)`. Use `sendRealtimeInput` for subsequent
+conversation input.
+
 #### Generate Content
 Use `generateContent` method for the most basic content generation.
 

--- a/src/main/java/com/google/genai/LiveConverters.java
+++ b/src/main/java/com/google/genai/LiveConverters.java
@@ -1283,6 +1283,13 @@ final class LiveConverters {
           Common.getValueByPath(fromObject, new String[] {"translationConfig"}));
     }
 
+    if (Common.getValueByPath(fromObject, new String[] {"historyConfig"}) != null) {
+      Common.setValueByPath(
+          parentObject,
+          new String[] {"setup", "historyConfig"},
+          Common.getValueByPath(fromObject, new String[] {"historyConfig"}));
+    }
+
     return toObject;
   }
 
@@ -1455,6 +1462,13 @@ final class LiveConverters {
       throw new IllegalArgumentException(
           "translationConfig parameter is only supported in Gemini Developer API mode, not in"
               + " Gemini Enterprise Agent Platform mode.");
+    }
+
+    if (Common.getValueByPath(fromObject, new String[] {"historyConfig"}) != null) {
+      Common.setValueByPath(
+          parentObject,
+          new String[] {"setup", "historyConfig"},
+          Common.getValueByPath(fromObject, new String[] {"historyConfig"}));
     }
 
     return toObject;

--- a/src/main/java/com/google/genai/types/LiveConnectConfig.java
+++ b/src/main/java/com/google/genai/types/LiveConnectConfig.java
@@ -173,6 +173,10 @@ public abstract class LiveConnectConfig extends JsonSerializable {
   @JsonProperty("translationConfig")
   public abstract Optional<TranslationConfig> translationConfig();
 
+  /** Configures the exchange of history between the client and the server. */
+  @JsonProperty("historyConfig")
+  public abstract Optional<HistoryConfig> historyConfig();
+
   /** Instantiates a builder for LiveConnectConfig. */
   @ExcludeFromGeneratedCoverageReport
   public static Builder builder() {
@@ -896,6 +900,34 @@ public abstract class LiveConnectConfig extends JsonSerializable {
     @CanIgnoreReturnValue
     public Builder clearTranslationConfig() {
       return translationConfig(Optional.empty());
+    }
+
+    /**
+     * Setter for historyConfig.
+     *
+     * <p>historyConfig: Configures the exchange of history between the client and the server.
+     */
+    @JsonProperty("historyConfig")
+    public abstract Builder historyConfig(HistoryConfig historyConfig);
+
+    /**
+     * Setter for historyConfig builder.
+     *
+     * <p>historyConfig: Configures the exchange of history between the client and the server.
+     */
+    @CanIgnoreReturnValue
+    public Builder historyConfig(HistoryConfig.Builder historyConfigBuilder) {
+      return historyConfig(historyConfigBuilder.build());
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    abstract Builder historyConfig(Optional<HistoryConfig> historyConfig);
+
+    /** Clears the value of historyConfig field. */
+    @ExcludeFromGeneratedCoverageReport
+    @CanIgnoreReturnValue
+    public Builder clearHistoryConfig() {
+      return historyConfig(Optional.empty());
     }
 
     public abstract LiveConnectConfig build();

--- a/src/main/resources/META-INF/native-image/com.google.genai/auto-value/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/auto-value/reflect-config.json
@@ -2400,6 +2400,22 @@
     "queryAllDeclaredConstructors": true
   },
   {
+    "name": "com.google.genai.types.AutoValue_HistoryConfig",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
+    "name": "com.google.genai.types.AutoValue_HistoryConfig$Builder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true
+  },
+  {
     "name": "com.google.genai.types.AutoValue_HttpOptions",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,

--- a/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.google.genai/google-genai/reflect-config.json
@@ -1381,6 +1381,13 @@
   "methods":[{"name":"dynamicRetrievalConfig","parameterTypes":[] }]
 },
 {
+  "name":"com.google.genai.types.AutoValue_HistoryConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"initialHistoryInClientContent","parameterTypes":[] }]
+},
+{
   "name":"com.google.genai.types.AutoValue_HttpOptions",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1595,7 +1602,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"avatarConfig","parameterTypes":[] }, {"name":"contextWindowCompression","parameterTypes":[] }, {"name":"enableAffectiveDialog","parameterTypes":[] }, {"name":"explicitVadSignal","parameterTypes":[] }, {"name":"httpOptions","parameterTypes":[] }, {"name":"inputAudioTranscription","parameterTypes":[] }, {"name":"maxOutputTokens","parameterTypes":[] }, {"name":"mediaResolution","parameterTypes":[] }, {"name":"outputAudioTranscription","parameterTypes":[] }, {"name":"proactivity","parameterTypes":[] }, {"name":"realtimeInputConfig","parameterTypes":[] }, {"name":"responseModalities","parameterTypes":[] }, {"name":"safetySettings","parameterTypes":[] }, {"name":"seed","parameterTypes":[] }, {"name":"sessionResumption","parameterTypes":[] }, {"name":"speechConfig","parameterTypes":[] }, {"name":"systemInstruction","parameterTypes":[] }, {"name":"temperature","parameterTypes":[] }, {"name":"thinkingConfig","parameterTypes":[] }, {"name":"tools","parameterTypes":[] }, {"name":"topK","parameterTypes":[] }, {"name":"topP","parameterTypes":[] }, {"name":"translationConfig","parameterTypes":[] }]
+  "methods":[{"name":"avatarConfig","parameterTypes":[] }, {"name":"contextWindowCompression","parameterTypes":[] }, {"name":"enableAffectiveDialog","parameterTypes":[] }, {"name":"explicitVadSignal","parameterTypes":[] }, {"name":"historyConfig","parameterTypes":[] }, {"name":"httpOptions","parameterTypes":[] }, {"name":"inputAudioTranscription","parameterTypes":[] }, {"name":"maxOutputTokens","parameterTypes":[] }, {"name":"mediaResolution","parameterTypes":[] }, {"name":"outputAudioTranscription","parameterTypes":[] }, {"name":"proactivity","parameterTypes":[] }, {"name":"realtimeInputConfig","parameterTypes":[] }, {"name":"responseModalities","parameterTypes":[] }, {"name":"safetySettings","parameterTypes":[] }, {"name":"seed","parameterTypes":[] }, {"name":"sessionResumption","parameterTypes":[] }, {"name":"speechConfig","parameterTypes":[] }, {"name":"systemInstruction","parameterTypes":[] }, {"name":"temperature","parameterTypes":[] }, {"name":"thinkingConfig","parameterTypes":[] }, {"name":"tools","parameterTypes":[] }, {"name":"topK","parameterTypes":[] }, {"name":"topP","parameterTypes":[] }, {"name":"translationConfig","parameterTypes":[] }]
 },
 {
   "name":"com.google.genai.types.AutoValue_LiveConnectConstraints",
@@ -3723,6 +3730,18 @@
   "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
 },
 {
+  "name":"com.google.genai.types.HistoryConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"com.google.genai.types.HistoryConfig$Builder",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"build","parameterTypes":[] }, {"name":"create","parameterTypes":[] }, {"name":"initialHistoryInClientContent","parameterTypes":["boolean"] }]
+},
+{
   "name":"com.google.genai.types.HttpElementLocation",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -4134,7 +4153,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"build","parameterTypes":[] }, {"name":"create","parameterTypes":[] }, {"name":"responseModalities","parameterTypes":["java.util.List"] }, {"name":"temperature","parameterTypes":["java.lang.Float"] }, {"name":"translationConfig","parameterTypes":["com.google.genai.types.TranslationConfig"] }]
+  "methods":[{"name":"build","parameterTypes":[] }, {"name":"create","parameterTypes":[] }, {"name":"historyConfig","parameterTypes":["com.google.genai.types.HistoryConfig"] }, {"name":"responseModalities","parameterTypes":["java.util.List"] }, {"name":"temperature","parameterTypes":["java.lang.Float"] }, {"name":"translationConfig","parameterTypes":["com.google.genai.types.TranslationConfig"] }]
 },
 {
   "name":"com.google.genai.types.LiveConnectConstraints",

--- a/src/test/java/com/google/genai/LiveConvertersTest.java
+++ b/src/test/java/com/google/genai/LiveConvertersTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.genai.types.Blob;
+import com.google.genai.types.HistoryConfig;
 import com.google.genai.types.LiveClientMessage;
 import com.google.genai.types.LiveConnectConfig;
 import com.google.genai.types.LiveSendRealtimeInputParameters;
@@ -188,5 +189,45 @@ public class LiveConvertersTest {
                 JsonSerializable.objectMapper
                     .createObjectNode()) // Code that should throw the exception
         );
+  }
+
+  @Test
+  public void testLiveConnectConfig_HistoryConfig_mldev() {
+    final LiveConnectConfig config =
+        LiveConnectConfig.builder()
+            .historyConfig(HistoryConfig.builder().initialHistoryInClientContent(true))
+            .build();
+    final ObjectNode transformed = JsonSerializable.objectMapper.createObjectNode();
+
+    new LiveConverters(GEMINI_API_CLIENT)
+        .liveConnectConfigToMldev(JsonSerializable.toJsonNode(config), transformed);
+
+    assertEquals(
+        true,
+        transformed
+            .get("setup")
+            .get("historyConfig")
+            .get("initialHistoryInClientContent")
+            .asBoolean());
+  }
+
+  @Test
+  public void testLiveConnectConfig_HistoryConfig_vertex() {
+    final LiveConnectConfig config =
+        LiveConnectConfig.builder()
+            .historyConfig(HistoryConfig.builder().initialHistoryInClientContent(true))
+            .build();
+    final ObjectNode transformed = JsonSerializable.objectMapper.createObjectNode();
+
+    new LiveConverters(VERTEX_AI_CLIENT)
+        .liveConnectConfigToVertex(JsonSerializable.toJsonNode(config), transformed);
+
+    assertEquals(
+        true,
+        transformed
+            .get("setup")
+            .get("historyConfig")
+            .get("initialHistoryInClientContent")
+            .asBoolean());
   }
 }


### PR DESCRIPTION
## Summary

Adds `historyConfig` support to `LiveConnectConfig`, enabling Java users to seed conversation history in Gemini 3.1 Live sessions.

Fixes #974.

## Root cause

`HistoryConfig` was available on the wire-level `LiveClientSetup`, but it was not exposed through the public `LiveConnectConfig` accepted by `AsyncLive.connect`. Consequently, callers could not enable initial history processing.

## Changes

- Expose `historyConfig` through `LiveConnectConfig` and its builder.
- Map the configuration to `setup.historyConfig` for both Gemini Developer API and Vertex AI.
- Add regression tests for both backend conversion paths.
- Update native-image reflection metadata.
- Document Gemini 3.1 Live history seeding in the README.

## Validation

- `mvn compile -DskipTests -Djacoco.skip=true`
- Checkstyle passes with zero violations.
- Native-image reflection JSON files parse successfully.
- `git diff --check` passes.
- Tests compile successfully. Local execution is blocked by the existing Mockito configuration not supporting the installed JDK 26; use a repository-supported JDK such as JDK 21.