### PR TITLE
fix: parse fractional-second Durations from the Live API

### DIFF
--- a/src/main/java/com/google/genai/JsonSerializable.java
+++ b/src/main/java/com/google/genai/JsonSerializable.java
@@ -78,8 +78,15 @@ public abstract class JsonSerializable {
       if (value.endsWith("s")) {
         String secondsPart = value.substring(0, value.length() - 1);
         try {
-          long seconds = Long.parseLong(secondsPart);
-          return java.time.Duration.ofSeconds(seconds);
+          // proto3 JSON encodes google.protobuf.Duration with FRACTIONAL
+          // seconds (e.g. "7.280s", up to 9 fractional digits), which the Live
+          // API streams. BigDecimal keeps full nanosecond precision and sign
+          // without floating-point error; plain integer parsing rejected them.
+          java.math.BigDecimal seconds = new java.math.BigDecimal(secondsPart);
+          long wholeSeconds = seconds.longValue();
+          long nanoAdjustment =
+              seconds.subtract(java.math.BigDecimal.valueOf(wholeSeconds)).movePointRight(9).longValue();
+          return java.time.Duration.ofSeconds(wholeSeconds, nanoAdjustment);
         } catch (NumberFormatException e) {
           throw ctxt.weirdStringException(
               value,

--- a/src/test/java/com/google/genai/JsonSerializableTest.java
+++ b/src/test/java/com/google/genai/JsonSerializableTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.genai.errors.GenAiIOException;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -130,5 +131,54 @@ class JsonSerializableTest {
               JsonSerializable.setMaxReadLength(-100);
             });
     assertEquals("Invalid JSON max read length: -100", ex2.getMessage());
+  }
+
+  /** A helper class with a Duration field, exercising CustomDurationDeserializer. */
+  static class DurationPayload extends JsonSerializable {
+    @JsonProperty("timeout")
+    public Duration timeout;
+  }
+
+  @Test
+  void fromJsonString_duration_parsesWholeSeconds() {
+    DurationPayload payload =
+        DurationPayload.fromJsonString("{\"timeout\":\"7s\"}", DurationPayload.class);
+
+    assertEquals(Duration.ofSeconds(7), payload.timeout);
+  }
+
+  @Test
+  void fromJsonString_duration_parsesFractionalSeconds() {
+    // proto3 JSON encodes google.protobuf.Duration with fractional seconds
+    // (e.g. "7.280s", up to 9 fractional digits); the Live API streams these.
+    DurationPayload payload =
+        DurationPayload.fromJsonString("{\"timeout\":\"7.280s\"}", DurationPayload.class);
+
+    assertEquals(Duration.ofSeconds(7, 280_000_000L), payload.timeout);
+  }
+
+  @Test
+  void fromJsonString_duration_keepsNanosecondPrecision() {
+    DurationPayload payload =
+        DurationPayload.fromJsonString("{\"timeout\":\"0.000000001s\"}", DurationPayload.class);
+
+    assertEquals(Duration.ofNanos(1), payload.timeout);
+  }
+
+  @Test
+  void fromJsonString_duration_parsesNegativeFractionalSeconds() {
+    DurationPayload payload =
+        DurationPayload.fromJsonString("{\"timeout\":\"-1.5s\"}", DurationPayload.class);
+
+    assertEquals(Duration.ofMillis(-1500), payload.timeout);
+  }
+
+  @Test
+  void fromJsonString_duration_rejectsNonNumericValue() {
+    assertThrows(
+        GenAiIOException.class,
+        () -> {
+          DurationPayload.fromJsonString("{\"timeout\":\"abcs\"}", DurationPayload.class);
+        });
   }
 }


### PR DESCRIPTION
Fixes #1120.

### Problem
`JsonSerializable.CustomDurationDeserializer` parses Durations with `Long.parseLong`, so it only accepts **whole** seconds (`"7s"`). But proto3 JSON encodes `google.protobuf.Duration` with **fractional** seconds (up to 9 digits), and the **Live API** (`BidiGenerateContent`) streams them (`"7.280s"`, `"1.600s"`, `"0.360s"`). The parse throws `NumberFormatException` → the whole Live WebSocket message fails to deserialize → the model turn / tool call is dropped. In a voice-agent app the assistant cuts off mid-sentence and no function call fires.

Observed in production on `gemini-3.1-flash-live-preview` (Vertex): ~700 of these errors in 24h across ~190 calls, with intermittently dropped calls when the bad message carried the response.

### Fix
Parse with `BigDecimal` — keeps full nanosecond precision and sign, no floating-point error, and matches the proto3 Duration wire format:

```java
java.math.BigDecimal seconds = new java.math.BigDecimal(secondsPart);
long wholeSeconds = seconds.longValue();
long nanoAdjustment =
    seconds.subtract(java.math.BigDecimal.valueOf(wholeSeconds)).movePointRight(9).longValue();
return java.time.Duration.ofSeconds(wholeSeconds, nanoAdjustment);
```

Whole seconds (`"5s"`), fractional (`"7.280s"`), and negative (`"-1.5s"`) all round-trip correctly; behaviour for the existing `"Xs"` case is unchanged.

The equivalent patch has been running in our production voice app and eliminated the deserialization errors.

I've signed / will sign the Google CLA.
