### PR TITLE
feat: surface Live API session close and error events to receive() callers

### DIFF
--- a/src/main/java/com/google/genai/AsyncLive.java
+++ b/src/main/java/com/google/genai/AsyncLive.java
@@ -216,6 +216,8 @@ public class AsyncLive {
     private final CompletableFuture<AsyncSession> sessionFuture;
     private final ApiClient apiClient;
     private Consumer<LiveServerMessage> messageCallback;
+    private Consumer<Throwable> errorCallback;
+    private Runnable closeCallback;
     private WebSocket webSocket;
 
     public GenAiWebSocketClient(
@@ -259,6 +261,14 @@ public class AsyncLive {
       this.messageCallback = messageCallback;
     }
 
+    public void setErrorCallback(Consumer<Throwable> errorCallback) {
+      this.errorCallback = errorCallback;
+    }
+
+    public void setCloseCallback(Runnable closeCallback) {
+      this.closeCallback = closeCallback;
+    }
+
     @Override
     public void onOpen(WebSocket webSocket, Response response) {
       this.webSocket = webSocket;
@@ -296,6 +306,8 @@ public class AsyncLive {
       if (!sessionFuture.isDone()) {
         sessionFuture.completeExceptionally(
             new GenAiIOException("WebSocket closed unexpectedly: " + reason));
+      } else if (closeCallback != null) {
+        closeCallback.run();
       }
     }
 
@@ -304,6 +316,8 @@ public class AsyncLive {
       logger.log(Level.SEVERE, "Error during live session", t);
       if (!sessionFuture.isDone()) {
         sessionFuture.completeExceptionally(t);
+      } else if (errorCallback != null) {
+        errorCallback.accept(t);
       }
     }
 

--- a/src/main/java/com/google/genai/AsyncSession.java
+++ b/src/main/java/com/google/genai/AsyncSession.java
@@ -128,7 +128,33 @@ public final class AsyncSession {
    *     *registration* of the callback.
    */
   public CompletableFuture<Void> receive(Consumer<LiveServerMessage> onMessage) {
+    return receive(onMessage, null, null);
+  }
+
+  /**
+   * Registers callbacks to receive messages and lifecycle events from the live session. Only one set
+   * of callbacks can be registered at a time; a later call replaces the previous one.
+   *
+   * <p>After the session is established, {@code onError} is invoked if the connection fails and
+   * {@code onClose} is invoked when the server closes the connection. These two are terminal and
+   * mutually exclusive (a failed connection reports {@code onError}, a normal close reports {@code
+   * onClose}); either may be {@code null} if not needed.
+   *
+   * @param onMessage A {@link Consumer} that will be called for each {@link LiveServerMessage}
+   *     received.
+   * @param onError A {@link Consumer} that will be called with the error if the connection fails
+   *     after the session is established, or {@code null}.
+   * @param onClose A {@link Runnable} that will be called when the server closes the connection after
+   *     the session is established, or {@code null}.
+   * @return A {@link CompletableFuture} that completes when the callbacks have been registered. Note:
+   *     This future doesn't represent the entire lifecycle of receiving messages, just the
+   *     *registration* of the callbacks.
+   */
+  public CompletableFuture<Void> receive(
+      Consumer<LiveServerMessage> onMessage, Consumer<Throwable> onError, Runnable onClose) {
     websocket.setMessageCallback(onMessage);
+    websocket.setErrorCallback(onError);
+    websocket.setCloseCallback(onClose);
     return CompletableFuture.completedFuture(null);
   }
 

--- a/src/test/java/com/google/genai/AsyncLiveTest.java
+++ b/src/test/java/com/google/genai/AsyncLiveTest.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -140,5 +142,40 @@ public class AsyncLiveTest {
     assertTrue(session.setupComplete() != null);
     assertTrue(session.setupComplete().voiceConsentSignature().isPresent());
     assertEquals("test_sig", session.setupComplete().voiceConsentSignature().get().signature().get());
+  }
+
+  @Test
+  public void testReceive_InvokesCloseCallbackOnServerClose() throws Exception {
+    CompletableFuture<AsyncSession> future = new CompletableFuture<>();
+    AsyncLive.GenAiWebSocketClient client =
+        new AsyncLive.GenAiWebSocketClient(
+            new URI("wss://test"), new HashMap<>(), "{}", future, apiClient);
+    client.onMessage("{\"setupComplete\":{}}");
+    AsyncSession session = future.get();
+
+    AtomicBoolean closed = new AtomicBoolean(false);
+    session.receive(message -> {}, null, () -> closed.set(true));
+
+    client.onClosed(null, 1000, "Server closing");
+
+    assertTrue(closed.get());
+  }
+
+  @Test
+  public void testReceive_InvokesErrorCallbackOnFailure() throws Exception {
+    CompletableFuture<AsyncSession> future = new CompletableFuture<>();
+    AsyncLive.GenAiWebSocketClient client =
+        new AsyncLive.GenAiWebSocketClient(
+            new URI("wss://test"), new HashMap<>(), "{}", future, apiClient);
+    client.onMessage("{\"setupComplete\":{}}");
+    AsyncSession session = future.get();
+
+    AtomicReference<Throwable> received = new AtomicReference<>();
+    session.receive(message -> {}, received::set, null);
+
+    RuntimeException error = new RuntimeException("connection failed");
+    client.onFailure(null, error, null);
+
+    assertEquals(error, received.get());
   }
 }


### PR DESCRIPTION
## What

After a Live session is established, `GenAiWebSocketClient` only *logs* `onClosed`/`onFailure` — they never reach the `receive()` consumer or any future, so a caller can't tell when the server closes the session or the connection drops.

This adds a backward-compatible overload that surfaces those events:

```java
public CompletableFuture<Void> receive(
    Consumer<LiveServerMessage> onMessage, Consumer<Throwable> onError, Runnable onClose)
```

`onError`/`onClose` are invoked from `onFailure`/`onClosed` after setup (terminal, mutually exclusive, nullable). The existing `receive(Consumer)` delegates to the overload, so its behavior is unchanged.

## Why

Found building the Gemini Live API integration for [langchain4j](https://github.com/langchain4j/langchain4j) — the wrapper had no way to notify the app when a session ends. See #1153.

## Tests

`AsyncLiveTest` covers the close and error paths.

Fixes #1153
